### PR TITLE
feat(clean): clean events pipeline with for_each parallelism and language patterns (closes #15)

### DIFF
--- a/.claude/commands/skill-llmops-commit-push.md
+++ b/.claude/commands/skill-llmops-commit-push.md
@@ -39,13 +39,22 @@ uv run pre-commit run --all-files
 
 If hooks fail with errors that cannot be auto-fixed, fix them manually, re-stage, and re-run. Do not proceed until all hooks pass.
 
-### 4. Run unit tests
+### 4. Run unit tests and check coverage
 
 ```bash
 uv run --extra ci pytest
 ```
 
-If any tests fail, stop and report the failures. Do not proceed until fixed.
+This command runs tests **and** enforces the coverage threshold (configured via `--cov-fail-under` in `pyproject.toml`). A non-zero exit code means either tests failed **or** coverage is below the threshold.
+
+If the run fails for any reason — test failures, coverage below threshold, or import errors — **stop immediately** and report the full failure output. Do not proceed until all tests pass and coverage is above the threshold.
+
+To identify which lines are uncovered and causing a coverage failure, run:
+```bash
+uv run --extra ci coverage report --include="*/artlake/*" -m
+```
+
+Common fix for Spark/Databricks entry-point functions that cannot be unit-tested: add `# pragma: no cover` to the function definition line.
 
 ### 5. Craft the commit message
 

--- a/config/output/language_patterns.yml
+++ b/config/output/language_patterns.yml
@@ -1,0 +1,26 @@
+generated_at: '2026-03-26T00:00:00+00:00'
+model: databricks-meta-llama-3-3-70b-instruct
+languages:
+- en
+- nl
+target_countries:
+- NL
+- BE
+title_keywords:
+  en:
+  - Title
+  - Event
+  - Name
+  nl:
+  - Titel
+  - Evenement
+  - Naam
+location_keywords:
+  en:
+  - Location
+  - Venue
+  - Address
+  - Place
+  nl:
+  - Locatie
+  - Adres

--- a/docs/artlake/ARCHITECTURE.md
+++ b/docs/artlake/ARCHITECTURE.md
@@ -78,7 +78,8 @@ Orchestrated as **Databricks Workflows**. Each step is a `.whl` entry point exec
 - **Search** (`artlake-search`, `artlake-search-social`) — reads pre-generated `queries.yml` and executes each query via `duckduckgo-search`. Results tagged with query language. Country names already included in queries (from generation step).
 - **Dedup + Seen-URL Tracking** (`artlake-dedup`) — fingerprints each URL with `sha2(url, 256)` and anti-joins against `artlake.staging.seen_urls`. Writes only unseen URLs to `seen_urls`, making it a persistent set across pipeline runs. Supports art aggregators where the domain is the same but event paths differ (each path produces a distinct hash).
 - **Page Scraper** (`artlake-scrape-pages`) — Two-mode entry point. `--mode list` anti-joins `seen_urls` against `scraped_pages` on `fingerprint` and emits the unseen URL list as a Databricks task value, feeding a `for_each_task` for per-URL parallelism and observability. `--mode scrape` fetches a single URL: checks `robots.txt` (stdlib `urllib.robotparser`), tries `/<domain>/llms.txt` first (higher-quality structured content where available), falls back to `requests` + BeautifulSoup raw HTML. Stores raw content only — title, body text, hrefs, artifact URLs. `fingerprint` written as PK. Date/location extraction deferred to downstream steps. Upgrade path: SerpAPI (paid) when JS-rendered pages or richer content extraction is needed.
-- **Clean Events** (`artlake-clean-events`) — reads `scraped_pages` (`processing_status = 'new'`), parses dates, normalises fields, writes `CleanEvent` records to `artlake.bronze.raw_events`. Sets `processing_status = 'outdated'` for events whose end date (or start date if no end) is in the past — skipping geocoding, artifact download, and translation for stale events. Sets `processing_status = 'new'` otherwise.
+- **Language Pattern Generation** (`artlake-generate-language-patterns`) — reads `config/input/keywords.yml`, calls LLM once to generate multilingual field-label patterns (title labels, location labels per language), writes `config/output/language_patterns.yml`. Re-run only when `keywords.yml` changes. Mirrors the `artlake-generate-queries` pattern.
+- **Clean Events** (`artlake-clean-events`) — two-mode entry point using `for_each_task` parallelism (mirrors `artlake-scrape-pages`). `--mode list` reads `scraped_pages` (`processing_status = 'new'`) and emits the URL list as a Databricks task value. `--mode clean --url <url>` processes one page: parses dates, normalises fields via rule-based extraction (using `language_patterns.yml` for multilingual field labels) with LLM fallback, writes one `CleanEvent` to `artlake.bronze.raw_events`. Sets `processing_status = 'outdated'` for past events, `requires_manual_validation` when extraction fails, `new` otherwise.
 - **Country Filter** (`artlake-geocode`) — reads `raw_events` (`processing_status = 'new'`), resolves location text → lat/lng/country via Nominatim (ADR-003). Keeps events in `target_countries`; sets `processing_status = 'done'` on accepted, `processing_status = 'failed'` on unresolvable locations (country kept as `'unknown'`). Lat/lng stored for future Phase 3 BI radius filtering (ADR-013).
 - **Artifact Downloader** (`artlake-download-artifacts`) — reads `artifact_urls` from `raw_events` (`processing_status = 'done'`), downloads PDFs and images to Unity Catalog Volumes.
 
@@ -88,16 +89,18 @@ Orchestrated as **Databricks Workflows**. Each step is a `.whl` entry point exec
 
 | Layer | Table | Content |
 |---|---|---|
-| Staging | `artlake.staging.search_results` | Raw search results, tagged with query language and source. |
+| Staging | `artlake.staging.search_results` | Raw search results, tagged with query language and source. `fingerprint` (sha2 of URL). |
 | Staging | `artlake.staging.seen_urls` | All URLs written by dedup — presence = seen. Persists across runs. Schema: url, title, source, fingerprint (sha2), ingested_at. |
 | Staging | `artlake.staging.scraped_pages` | Raw page content (title, body text, hrefs), artifact URLs. `fingerprint` (sha2, PK). `processing_status` column. |
 | Staging | `artlake.staging.artifacts` | Artifact metadata and UC Volume file paths. `processing_status` column. |
-| Bronze | `artlake.bronze.raw_events` | Structured clean events (title, description, dates, location, lat/lng, country, language, source, url) — original language |
+| Bronze | `artlake.bronze.raw_events` | Structured clean events (title, description, dates, location, lat/lng, country, language, source, url, `fingerprint`). `fingerprint` = sha2(url, 256) — consistent join key across all tables. |
 | Bronze | `artlake.bronze.translated_events` | Events translated to configured language (default: English) |
 | Gold | `artlake.gold.events` | Categorised (open_call / market / exhibition / workshop / other), enriched with artifact summaries |
 | Gold | `artlake.gold.embeddings` | Vector embeddings for semantic search (Delta Sync to Vector Search) — from translated content |
 
-**`processing_status`** — used on staging tables for expensive operations (`scraped_pages`, `artifacts`) to track row-level progress: `new` → `processing` → `done` | `failed`. Not used on `search_results` or `seen_urls` — those tables use simpler coordination (anti-join on `seen_urls`, presence in `scraped_pages`).
+**`processing_status`** — used on staging and bronze tables for expensive operations (`scraped_pages`, `artifacts`, `raw_events`) to track row-level progress: `new` → `processing` → `done` | `failed` | `outdated` | `requires_manual_validation`. Not used on `search_results` or `seen_urls` — those tables use simpler coordination (anti-join on `seen_urls`, presence in `scraped_pages`).
+
+**`fingerprint`** — `sha2(url, 256)` present on all tables as a consistent join key for BI and cross-table analysis. Computed from the canonical URL at write time.
 
 ### Processing Layer
 

--- a/docs/artlake/BACKLOG.md
+++ b/docs/artlake/BACKLOG.md
@@ -47,7 +47,8 @@ src/artlake/
 │   └── country.py           #   Geocoding + country filter         → artlake-geocode
 │
 ├── clean/                   # Raw → structured field extraction
-│   └── events.py            #   Parse dates, normalise fields      → artlake-clean-events
+│   ├── events.py            #   Parse dates, normalise fields      → artlake-clean-events
+│   └── patterns.py          #   Generate multilingual field-label patterns via LLM → artlake-generate-language-patterns
 │
 ├── categorise/              # Event type classification
 │   ├── rules.py             #   Keyword-based (multilingual)       → artlake-categorise-rules
@@ -88,7 +89,7 @@ Used on `scraped_pages` and `artifacts`. Downstream tasks read rows where upstre
 **Ingestion workflow:**
 ```
 artlake-generate-queries → artlake-search → artlake-search-social → artlake-dedup → artlake-scrape-pages
-→ artlake-clean-events → artlake-geocode → artlake-download-artifacts
+→ artlake-generate-language-patterns → artlake-clean-events (for_each) → artlake-geocode → artlake-download-artifacts
 ```
 
 **Processing workflow:**
@@ -111,8 +112,8 @@ artlake-translate → artlake-process-artifacts → artlake-categorise-rules →
 **Modules:** `models/event.py`, `models/config.py`
 
 **Models:**
-- `RawEvent` — url, title, snippet, source, raw_html, scraped_at, language (from query), artifact_urls
-- `CleanEvent` — title, description, date_start, date_end, location_text, lat, lng, country, language, source, url, artifact_paths
+- `RawEvent` — fingerprint (sha2), url, title, snippet, source, raw_html, scraped_at, language (from query), artifact_urls
+- `CleanEvent` — fingerprint (sha2), title, description, date_start, date_end, location_text, lat, lng, country, language, source, url, artifact_urls, artifact_paths
 - `GoldEvent` — extends CleanEvent with category, artifact_summaries
 - `EventArtifact` — url, artifact_type (pdf/image), file_path, extracted_text, llm_summary
 - `SeenUrl` — url, title, source, fingerprint (sha2(url, 256)), ingested_at
@@ -289,25 +290,34 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ### 1.9 — Clean events (raw → structured) — [#15](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/15)
 
-**Module:** `clean/events.py` → `artlake-clean-events`
+**Modules:**
+- `clean/patterns.py` → `artlake-generate-language-patterns` — reads `keywords.yml`, calls LLM once to generate multilingual field-label patterns, writes `config/output/language_patterns.yml`.
+- `clean/events.py` → `artlake-clean-events` — two-mode entry point with `for_each_task` parallelism.
 
 **Behaviour:**
-- Read from `artlake.staging.scraped_pages` where `processing_status = 'new'`
-- Parse dates (ISO, natural language, European dd/mm/yyyy)
-- Normalise titles, descriptions, location text
-- Copy `artifact_urls` from `scraped_pages` to `CleanEvent`
-- Write `CleanEvent` records to `artlake.bronze.raw_events`:
-  - `processing_status = 'outdated'` if `date_end < today` (or `date_start < today` when no end date)
-  - `processing_status = 'new'` otherwise (including events with no detected date)
+- `artlake-generate-language-patterns`: derive languages/target_countries from `keywords.yml`, call LLM for title/location field labels per language, write `language_patterns.yml` (mirrors `artlake-generate-queries` pattern)
+- `artlake-clean-events --mode list`: anti-join `scraped_pages` (`processing_status = 'new'`) and emit URL list as Databricks task value for `for_each_task`
+- `artlake-clean-events --mode clean --url <url>`: process one page per for_each iteration:
+  - Parse dates (ISO, natural language, European dd/mm/yyyy)
+  - Normalise title, description, location via rule-based extraction (using `language_patterns.yml` field labels per language)
+  - LLM fallback when fields are incomplete
+  - Copy `artifact_urls` and `fingerprint` from `scraped_pages` to `CleanEvent`
+  - Write to `artlake.bronze.raw_events`:
+    - `processing_status = 'outdated'` if `date_end < today`
+    - `processing_status = 'requires_manual_validation'` if extraction fails after LLM
+    - `processing_status = 'new'` otherwise
 
 **Acceptance criteria:**
-- [ ] Date parsing handles ISO, natural language, European dd/mm/yyyy formats
-- [ ] Events with past dates written with `processing_status = 'outdated'`
-- [ ] Events with no detected date written with `processing_status = 'new'`
-- [ ] Null handling for missing fields (description, dates, coordinates)
-- [ ] Unit tests for each parsing function
+- [x] Date parsing handles ISO, natural language, European dd/mm/yyyy formats
+- [x] Events with past dates written with `processing_status = 'outdated'`
+- [x] Events with no detected date written with `processing_status = 'new'`
+- [x] Null handling for missing fields (description, dates, coordinates)
+- [x] Unit tests for each parsing function
 - [ ] Integration test for Delta write (`@pytest.mark.integration`)
-- [ ] Entry point `artlake-clean-events` declared in `pyproject.toml`
+- [x] Entry point `artlake-clean-events` declared in `pyproject.toml`
+- [x] Entry point `artlake-generate-language-patterns` declared in `pyproject.toml`
+- [x] `for_each_task` pattern in `resources/clean_events_job.yml`
+- [x] `fingerprint` propagated from `scraped_pages` to `raw_events`
 
 ---
 

--- a/docs/artlake/BACKLOG.md
+++ b/docs/artlake/BACKLOG.md
@@ -1,8 +1,54 @@
 # ArtLake — Phase 1 & 2 Backlog Plan
 
+## Status overview
+
+### Done ✅
+| Story | Issue | Description |
+|---|---|---|
+| Pre-req | [#6](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/6) | Configure databricks.yml |
+| 1.1 | [#7](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/7) | Core data models (Pydantic schemas) |
+| 1.2 | [#8](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/8) | Multilingual keyword + query generation |
+| 1.3 | [#9](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/9) | DuckDuckGo search (general queries) |
+| 1.4 | [#10](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/10) | Social media site-scoped search |
+| 1.5 | [#11](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/11) | Deduplication + seen-URL tracking |
+| 1.6 | [#12](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/12) | Web page content scraper (for_each) |
+| 1.9 | [#15](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/15) | Clean events + language pattern generation (for_each) |
+
+### Up next — Phase 1 completion 🔜
+| Story | Issue | Description | Blocked by |
+|---|---|---|---|
+| 1.7 | [#13](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/13) | Artifact downloader (PDFs & images → UC Volumes) | #15 ✅ |
+| 1.8 | [#14](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/14) | Geocoding + country filter | #15 ✅ |
+| 1.10 | [#21](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/21) | Ingestion workflow definition | #13, #14 |
+
+### Phase 2: Processing 🔜
+| Story | Issue | Description | Blocked by |
+|---|---|---|---|
+| 2.1 | [#22](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/22) | Content translation | #15 ✅ |
+| 2.2 | [#16](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/16) | Artifact processing (ai_parse_document + LLM summary) | #13 |
+| 2.3 | [#17](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/17) | Rule-based event categorisation | #22 |
+| 2.4 | [#18](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/18) | LLM-based event categorisation | #17 |
+| 2.5 | [#19](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/19) | Vector embedding generation | #22, #17 |
+| 2.6 | [#23](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/23) | Processing workflow definition | #22, #16, #17, #19 |
+| 2.7 | [#20](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/20) | Vector Search index setup | #19 |
+| 2.8 | [#24](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/24) | End-to-end integration test | #21, #23 |
+
+### Recommended sequence
+```
+Now:   #14 (geocode) ── parallel ── #13 (artifact dl)
+            └──────────────────────────── #21 (ingestion workflow)
+                                               │
+       #22 (translate) ─── #17 (categorise) ─── #19 (embed) ─── #23 (processing workflow)
+                       └── #16 (artifact proc) ─┘
+                                          └── #20 (vector search)
+                                                       └── #24 (E2E test)
+```
+
+---
+
 ## Context
 
-ArtLake has architecture docs, ADRs, repo standards, CI, and tooling in place — but no application code yet. We need to create GitHub issues for the **Ingestion** and **Data Processing** phases. Phase 3 (Serving) deferred.
+ArtLake has architecture docs, ADRs, repo standards, CI, and tooling in place. Phase 1 ingestion is largely complete (#6–#12, #15). Phase 3 (Serving) deferred.
 
 ### Key decisions
 - **No notebooks for processing** — all steps are `.whl` entry points via `python_wheel_task`
@@ -101,13 +147,13 @@ artlake-translate → artlake-process-artifacts → artlake-categorise-rules →
 
 ## Pre-requisite
 
-### Configure databricks.yml — [#6](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/6)
+### ✅ Configure databricks.yml — [#6](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/6)
 
 ---
 
 ## Phase 1: Ingestion (Stories 1.1–1.10)
 
-### 1.1 — Core data models (Pydantic schemas) — [#7](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/7)
+### ✅ 1.1 — Core data models (Pydantic schemas) — [#7](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/7)
 
 **Modules:** `models/event.py`, `models/config.py`
 
@@ -126,7 +172,7 @@ artlake-translate → artlake-process-artifacts → artlake-categorise-rules →
 
 ---
 
-### 1.2 — Multilingual keyword generation — [#8](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/8)
+### ✅ 1.2 — Multilingual keyword generation — [#8](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/8)
 
 **Module:** `search/generate.py` → entry point `artlake-generate-queries`
 
@@ -143,7 +189,7 @@ artlake-translate → artlake-process-artifacts → artlake-categorise-rules →
 
 ---
 
-### 1.3 — DuckDuckGo search (general queries) — [#9](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/9)
+### ✅ 1.3 — DuckDuckGo search (general queries) — [#9](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/9)
 
 **Module:** `search/web.py` → `artlake-search`
 
@@ -161,7 +207,7 @@ artlake-translate → artlake-process-artifacts → artlake-categorise-rules →
 
 ---
 
-### 1.4 — Social media site-scoped search — [#10](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/10)
+### ✅ 1.4 — Social media site-scoped search — [#10](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/10)
 
 **Module:** `search/social.py` → `artlake-search-social`
 
@@ -192,7 +238,7 @@ Platforms are hand-authored config (not generated), so this file lives in `confi
 
 ---
 
-### 1.5 — Deduplication + seen-URL tracking — [#11](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/11)
+### ✅ 1.5 — Deduplication + seen-URL tracking — [#11](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/11)
 
 **Module:** `filter/dedup.py` → `artlake-dedup`
 
@@ -210,7 +256,7 @@ Platforms are hand-authored config (not generated), so this file lives in `confi
 
 ---
 
-### 1.6 — Web page content scraper — [#12](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/12)
+### ✅ 1.6 — Web page content scraper — [#12](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/12)
 
 **Module:** `scrape/pages.py` → `artlake-scrape-pages`
 
@@ -245,7 +291,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 1.7 — Artifact downloader — [#13](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/13)
+### 🔜 1.7 — Artifact downloader — [#13](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/13)
 
 **Module:** `scrape/download.py` → `artlake-download-artifacts`
 
@@ -265,7 +311,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 1.8 — Geocoding + country filter — [#14](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/14)
+### 🔜 1.8 — Geocoding + country filter — [#14](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/14)
 
 **Module:** `filter/country.py` → `artlake-geocode`
 
@@ -288,7 +334,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 1.9 — Clean events (raw → structured) — [#15](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/15)
+### ✅ 1.9 — Clean events (raw → structured) — [#15](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/15)
 
 **Modules:**
 - `clean/patterns.py` → `artlake-generate-language-patterns` — reads `keywords.yml`, calls LLM once to generate multilingual field-label patterns, writes `config/output/language_patterns.yml`.
@@ -321,7 +367,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 1.10 — Ingestion workflow definition — [#21](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/21)
+### 🔜 1.10 — Ingestion workflow definition — [#21](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/21)
 
 **Workflow:** `resources/ingest_events_job.yml`
 
@@ -339,7 +385,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ## Phase 2: Data Processing (Stories 2.1–2.8)
 
-### 2.1 — Content translation — [#22](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/22)
+### 🔜 2.1 — Content translation — [#22](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/22)
 
 **Module:** `translate/content.py` → `artlake-translate`
 
@@ -359,7 +405,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 2.2 — Artifact processing (`ai_parse_document` + LLM summary) — [#16](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/16)
+### 🔜 2.2 — Artifact processing (`ai_parse_document` + LLM summary) — [#16](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/16)
 
 **Module:** `process_artifacts/extract.py` → `artlake-process-artifacts`
 
@@ -378,7 +424,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 2.3 — Rule-based event categorisation — [#17](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/17)
+### 🔜 2.3 — Rule-based event categorisation — [#17](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/17)
 
 **Module:** `categorise/rules.py` → `artlake-categorise-rules`
 
@@ -396,7 +442,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 2.4 — LLM-based event categorisation — [#18](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/18)
+### 🔜 2.4 — LLM-based event categorisation — [#18](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/18)
 
 **Module:** `categorise/llm.py` → `artlake-categorise-llm`
 
@@ -412,7 +458,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 2.5 — Vector embedding generation — [#19](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/19)
+### 🔜 2.5 — Vector embedding generation — [#19](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/19)
 
 **Module:** `embed/generate.py` → `artlake-embed`
 
@@ -427,7 +473,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 2.6 — Processing workflow definition — [#23](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/23)
+### 🔜 2.6 — Processing workflow definition — [#23](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/23)
 
 **Workflow:** `resources/process_events_job.yml`
 
@@ -442,7 +488,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 2.7 — Vector Search index setup — [#20](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/20)
+### 🔜 2.7 — Vector Search index setup — [#20](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/20)
 
 **Module:** `embed/vector_search.py` (one-time setup)
 
@@ -457,7 +503,7 @@ No date/location extraction at this step — deferred to downstream `artlake-cle
 
 ---
 
-### 2.8 — End-to-end integration test — [#24](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/24)
+### 🔜 2.8 — End-to-end integration test — [#24](https://github.com/llmops-databricks-1/llmops-databricks-course-victor-kuznetsov/issues/24)
 
 **Behaviour:**
 - Run full ingestion workflow (search → clean-events) with test fixtures (mocked search results, saved HTML pages)

--- a/docs/artlake/DECISIONS.md
+++ b/docs/artlake/DECISIONS.md
@@ -330,24 +330,25 @@ client = OpenAI(
 
 ## ADR-023 · Clean Events — Multi-Language Extraction Funnel
 
-**Decision**: Parse scraped pages into structured `CleanEvent` records using a **cost-reducing funnel**: rule-based date parsing → early outdated filter → rule-based field extraction → cheap LLM fallback → `requires_manual_validation` if still incomplete.
+**Decision**: Parse scraped pages into structured `CleanEvent` records using a **cost-reducing funnel**: rule-based date parsing → early outdated filter → rule-based field extraction (driven by LLM-generated `language_patterns.yml`) → cheap LLM fallback → `requires_manual_validation` if still incomplete. Uses `for_each_task` for per-URL parallelism (mirrors `artlake-scrape-pages` pattern).
 
 **Rationale**:
 
 - Scraped pages arrive in any language (EN/NL/DE/FR) and any format — a purely rule-based approach cannot handle all cases, but calling an LLM on every page is wasteful.
 - Filtering outdated events early (before LLM calls) prevents paying for compute on stale data. Events with no detected date are assumed ongoing and pass through.
 - `dateparser` (open-source, 200+ languages) handles ISO, European `dd/mm/yyyy`, and natural-language date formats in all target languages. No API cost.
-- Rule-based field extraction (title from scraped `<title>`, description from first 500 chars, location via keyword regex) covers the majority of well-structured pages for free.
+- Rule-based field extraction uses a **generated `language_patterns.yml`** (via `artlake-generate-language-patterns`, see ADR-024) for multilingual field labels — no hardcoded constants that would silently break when target languages change.
 - LLM fallback (Databricks FM — `databricks-meta-llama-3-3-70b-instruct`, cheap + Databricks-native) is called only when rule-based extraction leaves fields incomplete. LLM also fills date gaps and re-checks outdated status after filling.
 - Records where even the LLM cannot extract structured fields are marked `requires_manual_validation` — visible for human review without blocking the pipeline.
 - Language is resolved by joining `scraped_pages` with `staging.search_results` on `url`; defaults to `"unknown"` when missing. Downstream `artlake-translate` handles the `"unknown"` case.
+- `for_each_task` gives per-URL observability and retry granularity in the Databricks job UI (same rationale as ADR-022).
 
 **Processing status added**: `requires_manual_validation` — new value in `ProcessingStatus` enum, alongside `new`, `processing`, `done`, `failed`, `outdated`.
 
 **Funnel steps**:
-1. `parse_dates(raw_text)` — `dateparser.search.search_dates`, multi-language, filters dates > 2 years old (publication/copyright noise).
+1. `parse_dates(raw_text, languages)` — `dateparser.search.search_dates`, multi-language, filters dates > 100 years old (publication/copyright noise).
 2. `is_outdated(date_start, date_end)` → write `CleanEvent(processing_status='outdated')`, skip LLM.
-3. `extract_fields_rule_based(page)` — title, description, location via regex.
+3. `extract_fields_rule_based(page, title_re, location_re)` — title (labeled field → `<title>` tag → first line), description from first 500 chars, location via keyword regex built from `language_patterns.yml`.
 4. `extract_fields_llm(page, client, model)` — called only when fields incomplete; also fills date gaps and re-checks outdated.
 5. `requires_manual_validation` if still incomplete after LLM.
 
@@ -355,6 +356,38 @@ client = OpenAI(
 - LLM-only extraction on every page — unnecessary cost at scale; dateparser covers the majority of date formats for free.
 - Separate language detection step — search queries already control language (ADR-004); `"unknown"` fallback is sufficient for this step.
 - Single-pass rule-based only — fails on non-English / non-structured pages.
+- Hardcoded language constants (`_LANGUAGES`, `_TLD_COUNTRY`) — silently break when target languages/countries change; replaced by `language_patterns.yml` (ADR-024).
+
+---
+
+## ADR-024 · Language Pattern Generation
+
+**Decision**: Generate multilingual field-label patterns (`language_patterns.yml`) via LLM from `keywords.yml` as a **pre-processing step** before `artlake-clean-events`. Single LLM call produces all `title_keywords` and `location_keywords` per target language. Mirrors the `artlake-generate-queries` pattern.
+
+**Rationale**:
+- `artlake-clean-events` needs per-language field labels (e.g. `"Titel:"`, `"Locatie:"`) to find structured content on pages — these cannot be hardcoded without risking silent breakage when languages change.
+- Deriving labels from `keywords.yml` (which already lists all target languages and countries) ensures the patterns stay in sync with the pipeline configuration automatically.
+- One LLM call at the job level amortises the cost over all per-URL iterations; calling the LLM per page for label generation would be wasteful.
+- The pattern file is written to the workspace shared path (`${var.config_root}/config/output/`) via DAB, so all concurrent `for_each_task` iterations read it without contention.
+
+**Output** (`language_patterns.yml`):
+```yaml
+languages: [en, nl, de, fr]
+target_countries: [NL, BE, DE, FR]
+title_keywords:
+  en: [Title, Event, Name]
+  nl: [Titel, Evenement, Naam]
+  ...
+location_keywords:
+  en: [Location, Venue, Address, Place]
+  nl: [Locatie, Adres]
+  ...
+```
+
+**Rejected**:
+- Hardcoded module-level constants — silently stale when languages/countries change.
+- Reading `keywords.yml` directly in `clean_events` — adds config-parsing complexity to a task already responsible for extraction; violates single-responsibility principle.
+- Per-URL LLM calls for label generation — wasteful; labels don't change between pages.
 
 ---
 

--- a/docs/artlake/DECISIONS.md
+++ b/docs/artlake/DECISIONS.md
@@ -328,12 +328,44 @@ client = OpenAI(
 
 ---
 
+## ADR-023 · Clean Events — Multi-Language Extraction Funnel
+
+**Decision**: Parse scraped pages into structured `CleanEvent` records using a **cost-reducing funnel**: rule-based date parsing → early outdated filter → rule-based field extraction → cheap LLM fallback → `requires_manual_validation` if still incomplete.
+
+**Rationale**:
+
+- Scraped pages arrive in any language (EN/NL/DE/FR) and any format — a purely rule-based approach cannot handle all cases, but calling an LLM on every page is wasteful.
+- Filtering outdated events early (before LLM calls) prevents paying for compute on stale data. Events with no detected date are assumed ongoing and pass through.
+- `dateparser` (open-source, 200+ languages) handles ISO, European `dd/mm/yyyy`, and natural-language date formats in all target languages. No API cost.
+- Rule-based field extraction (title from scraped `<title>`, description from first 500 chars, location via keyword regex) covers the majority of well-structured pages for free.
+- LLM fallback (Databricks FM — `databricks-meta-llama-3-3-70b-instruct`, cheap + Databricks-native) is called only when rule-based extraction leaves fields incomplete. LLM also fills date gaps and re-checks outdated status after filling.
+- Records where even the LLM cannot extract structured fields are marked `requires_manual_validation` — visible for human review without blocking the pipeline.
+- Language is resolved by joining `scraped_pages` with `staging.search_results` on `url`; defaults to `"unknown"` when missing. Downstream `artlake-translate` handles the `"unknown"` case.
+
+**Processing status added**: `requires_manual_validation` — new value in `ProcessingStatus` enum, alongside `new`, `processing`, `done`, `failed`, `outdated`.
+
+**Funnel steps**:
+1. `parse_dates(raw_text)` — `dateparser.search.search_dates`, multi-language, filters dates > 2 years old (publication/copyright noise).
+2. `is_outdated(date_start, date_end)` → write `CleanEvent(processing_status='outdated')`, skip LLM.
+3. `extract_fields_rule_based(page)` — title, description, location via regex.
+4. `extract_fields_llm(page, client, model)` — called only when fields incomplete; also fills date gaps and re-checks outdated.
+5. `requires_manual_validation` if still incomplete after LLM.
+
+**Rejected**:
+- LLM-only extraction on every page — unnecessary cost at scale; dateparser covers the majority of date formats for free.
+- Separate language detection step — search queries already control language (ADR-004); `"unknown"` fallback is sufficient for this step.
+- Single-pass rule-based only — fails on non-English / non-structured pages.
+
+---
+
 ## Summary
 
 | Layer | Tool | Cost |
 |---|---|---|
 | Search | `duckduckgo-search` (SerpAPI upgrade path) | Free |
 | Scraping | `requests` + `beautifulsoup4` | Free |
+| Date parsing | `dateparser` (multi-language, 200+ languages) | Free |
+| Event cleaning | Rule-based → LLM fallback (Databricks FM) | Free / Databricks-native |
 | Geocoding | Nominatim / `geopy` | Free |
 | Language targeting | Multilingual keyword generation (search-level) | Free |
 | Content translation | Databricks Foundation Model API | Databricks-native |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ include = ["artlake*"]
 version = { file = "version.txt" }
 
 [tool.pytest.ini_options]
-addopts = "-s --no-header --no-summary --cov=artlake --cov-report=term-missing --cov-fail-under=80"
+addopts = "-s --no-header --no-summary --cov=artlake --cov-report=term-missing --cov-fail-under=80 -m 'not integration'"
 testpaths = ["tests"]
 pythonpath = ["."]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "typer==0.24.1",
     "ddgs==9.11.4",
     "requests==2.32.3",
-    "beautifulsoup4==4.13.4"
+    "beautifulsoup4==4.13.4",
+    "dateparser==1.2.1"
 ]
 
 [project.scripts]
@@ -33,6 +34,7 @@ artlake-search = "artlake.search.web:main"
 artlake-search-social = "artlake.search.social:main"
 artlake-dedup = "artlake.filter.dedup:main"
 artlake-scrape-pages = "artlake.scrape.pages:main"
+artlake-clean-events = "artlake.clean.events:main"
 
 [project.optional-dependencies]
 dev = ["databricks-connect>=17.0, <18",
@@ -115,6 +117,7 @@ module = [
     "databricks.sdk.*",
     "bs4",
     "requests",
+    "dateparser",
     "ddgs",
     "ddgs.*",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ artlake-search-social = "artlake.search.social:main"
 artlake-dedup = "artlake.filter.dedup:main"
 artlake-scrape-pages = "artlake.scrape.pages:main"
 artlake-clean-events = "artlake.clean.events:main"
+artlake-generate-language-patterns = "artlake.clean.patterns:main"
 
 [project.optional-dependencies]
 dev = ["databricks-connect>=17.0, <18",

--- a/resources/clean_events_job.yml
+++ b/resources/clean_events_job.yml
@@ -13,19 +13,57 @@ resources:
               - ../dist/*.whl
 
       tasks:
-        - task_key: clean_events
+        - task_key: list_urls
           environment_key: default
           python_wheel_task:
             entry_point: artlake-clean-events
             package_name: artlake
             parameters:
+              - "--mode"
+              - "list"
               - "--scraped-pages-table"
               - "artlake.staging.scraped_pages"
               - "--search-results-table"
               - "artlake.staging.search_results"
-              - "--raw-events-table"
-              - "artlake.bronze.raw_events"
-              - "--model"
-              - "databricks-meta-llama-3-3-70b-instruct"
               - "--env"
               - "${bundle.target}"
+
+        - task_key: clean_events
+          depends_on:
+            - task_key: list_urls
+          for_each_task:
+            inputs: "{{tasks.list_urls.values.urls}}"
+            concurrency: 10
+            task:
+              task_key: clean_event_iteration
+              max_retries: 1
+              environment_key: default
+              python_wheel_task:
+                entry_point: artlake-clean-events
+                package_name: artlake
+                parameters:
+                  - "--mode"
+                  - "clean"
+                  - "--url"
+                  - "{{input}}"
+                  - "--scraped-pages-table"
+                  - "artlake.staging.scraped_pages"
+                  - "--search-results-table"
+                  - "artlake.staging.search_results"
+                  - "--raw-events-table"
+                  - "artlake.bronze.raw_events"
+                  - "--model"
+                  - "databricks-meta-llama-3-3-70b-instruct"
+                  - "--env"
+                  - "${bundle.target}"
+                  - "--languages"
+                  - "en"
+                  - "nl"
+                  - "de"
+                  - "fr"
+                  - "--target-countries"
+                  - "NL"
+                  - "BE"
+                  - "DE"
+                  - "FR"
+                  - "LU"

--- a/resources/clean_events_job.yml
+++ b/resources/clean_events_job.yml
@@ -38,6 +38,8 @@ resources:
               - "artlake.staging.scraped_pages"
               - "--search-results-table"
               - "artlake.staging.search_results"
+              - "--language-patterns"
+              - "${var.config_root}/config/output/language_patterns.yml"
               - "--env"
               - "${bundle.target}"
 

--- a/resources/clean_events_job.yml
+++ b/resources/clean_events_job.yml
@@ -1,0 +1,31 @@
+resources:
+  jobs:
+    clean_events_job:
+      name: clean-events
+      tags:
+        project_name: "artlake"
+
+      environments:
+        - environment_key: default
+          spec:
+            environment_version: "4"
+            dependencies:
+              - ../dist/*.whl
+
+      tasks:
+        - task_key: clean_events
+          environment_key: default
+          python_wheel_task:
+            entry_point: artlake-clean-events
+            package_name: artlake
+            parameters:
+              - "--scraped-pages-table"
+              - "artlake.staging.scraped_pages"
+              - "--search-results-table"
+              - "artlake.staging.search_results"
+              - "--raw-events-table"
+              - "artlake.bronze.raw_events"
+              - "--model"
+              - "databricks-meta-llama-3-3-70b-instruct"
+              - "--env"
+              - "${bundle.target}"

--- a/resources/clean_events_job.yml
+++ b/resources/clean_events_job.yml
@@ -13,7 +13,20 @@ resources:
               - ../dist/*.whl
 
       tasks:
+        - task_key: generate_language_patterns
+          environment_key: default
+          python_wheel_task:
+            entry_point: artlake-generate-language-patterns
+            package_name: artlake
+            parameters:
+              - "--keywords"
+              - "${var.config_root}/config/input/keywords.yml"
+              - "--output"
+              - "${var.config_root}/config/output/language_patterns.yml"
+
         - task_key: list_urls
+          depends_on:
+            - task_key: generate_language_patterns
           environment_key: default
           python_wheel_task:
             entry_point: artlake-clean-events
@@ -54,16 +67,7 @@ resources:
                   - "artlake.bronze.raw_events"
                   - "--model"
                   - "databricks-meta-llama-3-3-70b-instruct"
+                  - "--language-patterns"
+                  - "${var.config_root}/config/output/language_patterns.yml"
                   - "--env"
                   - "${bundle.target}"
-                  - "--languages"
-                  - "en"
-                  - "nl"
-                  - "de"
-                  - "fr"
-                  - "--target-countries"
-                  - "NL"
-                  - "BE"
-                  - "DE"
-                  - "FR"
-                  - "LU"

--- a/resources/generate_language_patterns_job.yml
+++ b/resources/generate_language_patterns_job.yml
@@ -1,0 +1,23 @@
+resources:
+  jobs:
+    generate_language_patterns_job:
+      name: generate-language-patterns
+      tags:
+        project_name: "artlake"
+      environments:
+        - environment_key: default
+          spec:
+            environment_version: "4"
+            dependencies:
+              - ../dist/*.whl
+      tasks:
+        - task_key: generate_language_patterns
+          environment_key: default
+          python_wheel_task:
+            entry_point: artlake-generate-language-patterns
+            package_name: artlake
+            parameters:
+              - "--keywords"
+              - "${var.config_root}/config/input/keywords.yml"
+              - "--output"
+              - "${var.config_root}/config/output/language_patterns.yml"

--- a/src/artlake/clean/events.py
+++ b/src/artlake/clean/events.py
@@ -12,8 +12,10 @@ Extraction funnel per page:
 
 from __future__ import annotations
 
+import html
 import json
 import re
+import unicodedata
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 
@@ -118,6 +120,29 @@ def is_outdated(date_start: datetime | None, date_end: datetime | None) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Text normalisation
+# ---------------------------------------------------------------------------
+
+# Site-name suffix patterns: "Title | Gallery", "Title - Site", "Title – Brand"
+_TITLE_SUFFIX_RE = re.compile(r"\s*[|\-–—]\s*.+$")
+
+
+def _normalize_text(text: str) -> str:
+    """Decode HTML entities, normalize unicode (NFKC), collapse whitespace."""
+    text = html.unescape(text)
+    text = unicodedata.normalize("NFKC", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _clean_title(title: str) -> str:
+    """Normalize title and strip common site-name suffixes (| … / - … / – …)."""
+    title = _normalize_text(title)
+    title = _TITLE_SUFFIX_RE.sub("", title).strip()
+    return title
+
+
+# ---------------------------------------------------------------------------
 # Rule-based field extraction
 # ---------------------------------------------------------------------------
 
@@ -136,22 +161,28 @@ def extract_fields_rule_based(page: ScrapedPage) -> dict[str, str | None]:
     """Extract title, description, and location_text using heuristics.
 
     Returns a dict with string-or-None values for each field.
+    All extracted strings are normalised (HTML entities decoded, unicode
+    normalised, whitespace collapsed).
     """
-    title: str | None = page.title.strip() if page.title else None
+    title: str | None = _clean_title(page.title) if page.title else None
 
     # Fallback: first meaningful line of raw_text
     if not title and page.raw_text:
         for line in page.raw_text.splitlines():
-            stripped = line.strip()
+            stripped = _normalize_text(line)
             if len(stripped) > 10:
-                title = stripped[:200]
+                title = _clean_title(stripped[:200])
                 break
 
     description: str | None = None
     if page.raw_text:
-        description = page.raw_text[:500].strip() or None
+        raw = _normalize_text(page.raw_text[:500])
+        description = raw or None
 
-    location_text = _extract_location(page.raw_text) if page.raw_text else None
+    location_text: str | None = None
+    if page.raw_text:
+        raw_loc = _extract_location(page.raw_text)
+        location_text = _normalize_text(raw_loc) if raw_loc else None
 
     return {"title": title, "description": description, "location_text": location_text}
 

--- a/src/artlake/clean/events.py
+++ b/src/artlake/clean/events.py
@@ -325,6 +325,7 @@ def _make_clean_event(
     target_countries: list[str],
 ) -> CleanEvent:
     return CleanEvent(
+        fingerprint=page.fingerprint,
         title=fields.get("title") or page.title or str(page.url),
         description=fields.get("description") or "",
         date_start=date_start,
@@ -460,6 +461,7 @@ def _clean_event_schema() -> StructType:  # pragma: no cover
 
     return StructType(
         [
+            StructField("fingerprint", StringType(), False),
             StructField("title", StringType(), False),
             StructField("description", StringType(), False),
             StructField("date_start", TimestampType(), True),

--- a/src/artlake/clean/events.py
+++ b/src/artlake/clean/events.py
@@ -413,10 +413,10 @@ def run_clean(  # pragma: no cover
             raw_text=row["raw_text"] or "",
             artifact_urls=list(row["artifact_urls"] or []),
             processing_status=ProcessingStatus(row["processing_status"]),
-            robots_allowed=row.get("robots_allowed"),
-            error=row.get("error"),
+            robots_allowed=row["robots_allowed"],
+            error=row["error"],
         )
-        language = row.get("language") or "unknown"
+        language = row["language"] or "unknown"
         event = clean_page(page, language, client, model)
         r = event.model_dump(mode="json")
         r["url"] = str(r["url"])

--- a/src/artlake/clean/events.py
+++ b/src/artlake/clean/events.py
@@ -418,7 +418,8 @@ def run_clean(  # pragma: no cover
         )
         language = row["language"] or "unknown"
         event = clean_page(page, language, client, model)
-        r = event.model_dump(mode="json")
+        # mode="python" preserves datetime objects — required for TimestampType columns
+        r = event.model_dump(mode="python")
         r["url"] = str(r["url"])
         r["ingested_at"] = str(r["ingested_at"])
         clean_rows.append(r)

--- a/src/artlake/clean/events.py
+++ b/src/artlake/clean/events.py
@@ -17,7 +17,12 @@ import json
 import re
 import unicodedata
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+    from pyspark.sql.types import StructType
 
 import backoff
 from loguru import logger
@@ -31,8 +36,9 @@ from artlake.models.event import CleanEvent, ProcessingStatus, ScrapedPage
 
 _DATE_SEARCH_CHARS = 3000  # chars fed to dateparser.search
 _TEXT_TRUNCATE = 3000  # chars sent to LLM
-_DATE_HORIZON_DAYS = 730  # filter out dates > 2 years old (publication/copyright dates)
-_LANGUAGES = ["en", "nl", "de", "fr"]
+_DATE_HORIZON_DAYS = 730  # filter out dates > 2 years old (publication/copyright noise)
+_DATE_FUTURE_DAYS = 365 * 100  # filter out dates > 100 years ahead (parser artefacts)
+
 
 _LOCATION_RE = re.compile(
     r"(?:^|\b)(?:Location|Venue|Address|Place|Locatie|Adresse|Adres|Ort|Lieu|Endroit)"
@@ -66,29 +72,40 @@ Text:
 # ---------------------------------------------------------------------------
 
 
-def parse_dates(text: str) -> tuple[datetime | None, datetime | None]:
+def parse_dates(
+    text: str, languages: list[str] | None = None
+) -> tuple[datetime | None, datetime | None]:
     """Extract start and end dates from raw text using dateparser.
 
     Returns (date_start, date_end). Both may be None if no dates are found.
     Dates more than two years in the past are discarded (copyright / publication noise).
+
+    Args:
+        text: Raw page text to search for dates.
+        languages: BCP-47 language codes to pass to dateparser (e.g. ["en", "nl"]).
+            Defaults to ["en"] when None. Passing None to dateparser enables
+            auto-detection across all languages, which produces too many false
+            positives (e.g. common words parsed as today's date).
     """
     from dateparser.search import search_dates  # type: ignore[import-untyped]
 
     snippet = text[:_DATE_SEARCH_CHARS]
     results = search_dates(
         snippet,
-        languages=_LANGUAGES,
+        languages=languages or ["en"],
         settings={"PREFER_DAY_OF_MONTH": "first", "RETURN_AS_TIMEZONE_AWARE": True},
     )
     if not results:
         return None, None
 
-    cutoff = datetime.now(UTC) - timedelta(days=_DATE_HORIZON_DAYS)
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(days=_DATE_HORIZON_DAYS)
+    max_future = now + timedelta(days=_DATE_FUTURE_DAYS)
     seen: set[tuple[int, int, int]] = set()
     dates: list[datetime] = []
     for _, dt in results:
         key = (dt.year, dt.month, dt.day)
-        if key not in seen and dt >= cutoff:
+        if key not in seen and cutoff <= dt <= max_future:
             seen.add(key)
             dates.append(dt)
 
@@ -166,11 +183,16 @@ def extract_fields_rule_based(page: ScrapedPage) -> dict[str, str | None]:
     """
     title: str | None = _clean_title(page.title) if page.title else None
 
-    # Fallback: first meaningful line of raw_text
+    # If raw_text is unparsed HTML the scraper failed to extract properly —
+    # return all None to force the LLM fallback on the full funnel step.
+    if page.raw_text and _looks_like_html(page.raw_text):
+        return {"title": title, "description": None, "location_text": None}
+
+    # Fallback: first meaningful non-HTML line of raw_text
     if not title and page.raw_text:
         for line in page.raw_text.splitlines():
             stripped = _normalize_text(line)
-            if len(stripped) > 10:
+            if len(stripped) > 10 and not stripped.startswith("<"):
                 title = _clean_title(stripped[:200])
                 break
 
@@ -265,6 +287,25 @@ def _source_from_url(url: str) -> str:
     return urlparse(url).netloc or str(url)
 
 
+def _country_from_url(url: str, target_countries: list[str]) -> str | None:
+    """Infer ISO-3166-1 alpha-2 country code from URL TLD.
+
+    Checks whether the URL's hostname ends with a ccTLD that matches one of the
+    configured target_countries codes (e.g. "NL" → ".nl").
+    """
+    netloc = urlparse(url).netloc.lower()
+    for code in target_countries:
+        if netloc.endswith(f".{code.lower()}"):
+            return code
+    return None
+
+
+def _looks_like_html(text: str) -> bool:
+    """Return True when raw_text is unparsed HTML (scraper fallback artefact)."""
+    stripped = text.lstrip()
+    return stripped.startswith("<!DOCTYPE") or stripped.startswith("<html")
+
+
 def _make_clean_event(
     page: ScrapedPage,
     language: str,
@@ -272,6 +313,7 @@ def _make_clean_event(
     date_end: datetime | None,
     fields: dict[str, str | None],
     status: ProcessingStatus,
+    target_countries: list[str],
 ) -> CleanEvent:
     return CleanEvent(
         title=fields.get("title") or page.title or str(page.url),
@@ -283,6 +325,7 @@ def _make_clean_event(
         source=_source_from_url(str(page.url)),
         url=page.url,
         artifact_urls=page.artifact_urls,
+        country=_country_from_url(str(page.url), target_countries),
         processing_status=status,
     )
 
@@ -297,6 +340,9 @@ def clean_page(
     language: str,
     client: OpenAI,
     model: str,
+    *,
+    languages: list[str] | None = None,
+    target_countries: list[str] | None = None,
 ) -> CleanEvent:
     """Apply the extraction funnel to a single ScrapedPage and return a CleanEvent.
 
@@ -306,16 +352,34 @@ def clean_page(
       3. Extract fields rule-based.
       4. LLM fallback for incomplete fields; re-check outdated after LLM date fill.
       5. status='requires_manual_validation' if fields are still incomplete.
+
+    Args:
+        page: Scraped page to process.
+        language: BCP-47 language code for this page (from search_results join).
+        client: OpenAI-compatible client pointed at Databricks Foundation Models.
+        model: Model ID for LLM fallback extraction.
+        languages: Languages to pass to dateparser (from ArtLakeConfig.languages).
+            None lets dateparser auto-detect (slower).
+        target_countries: ISO-3166-1 alpha-2 codes for TLD → country inference
+            (from ArtLakeConfig.target_countries).
     """
+    _target_countries = target_countries or []
+
     # Step 1 — rule-based date parsing
-    date_start, date_end = parse_dates(page.raw_text or "")
+    date_start, date_end = parse_dates(page.raw_text or "", languages)
 
     # Step 2 — filter outdated early (skip expensive steps below)
     if is_outdated(date_start, date_end):
         logger.info("Outdated event (rule-based dates): {}", page.url)
         fields = extract_fields_rule_based(page)
         return _make_clean_event(
-            page, language, date_start, date_end, fields, ProcessingStatus.OUTDATED
+            page,
+            language,
+            date_start,
+            date_end,
+            fields,
+            ProcessingStatus.OUTDATED,
+            _target_countries,
         )
 
     # Step 3 — rule-based field extraction
@@ -342,6 +406,7 @@ def clean_page(
                     date_end,
                     fields,
                     ProcessingStatus.OUTDATED,
+                    _target_countries,
                 )
 
     # Step 5 — determine final status
@@ -353,12 +418,187 @@ def clean_page(
     if status == ProcessingStatus.REQUIRES_MANUAL_VALIDATION:
         logger.warning("Incomplete extraction, manual validation needed: {}", page.url)
 
-    return _make_clean_event(page, language, date_start, date_end, fields, status)
+    return _make_clean_event(
+        page, language, date_start, date_end, fields, status, _target_countries
+    )
 
 
 # ---------------------------------------------------------------------------
 # Spark integration (pragma: no cover — tested via integration marker)
 # ---------------------------------------------------------------------------
+
+
+def _build_openai_client() -> OpenAI:  # pragma: no cover
+    """Create an OpenAI-compatible client backed by Databricks Foundation Models."""
+    from databricks.sdk import WorkspaceClient
+
+    w = WorkspaceClient()
+    token = w.tokens.create(lifetime_seconds=1200).token_value
+    host = w.config.host or ""
+    return OpenAI(
+        api_key=token,
+        base_url=f"{host.rstrip('/')}/serving-endpoints",
+    )
+
+
+def _clean_event_schema() -> StructType:  # pragma: no cover
+    """Return the Spark StructType schema for CleanEvent rows."""
+    from pyspark.sql.types import (
+        ArrayType,
+        FloatType,
+        StringType,
+        StructField,
+        StructType,
+        TimestampType,
+    )
+
+    return StructType(
+        [
+            StructField("title", StringType(), False),
+            StructField("description", StringType(), False),
+            StructField("date_start", TimestampType(), True),
+            StructField("date_end", TimestampType(), True),
+            StructField("location_text", StringType(), False),
+            StructField("lat", FloatType(), True),
+            StructField("lng", FloatType(), True),
+            StructField("country", StringType(), True),
+            StructField("language", StringType(), False),
+            StructField("source", StringType(), False),
+            StructField("url", StringType(), False),
+            StructField("artifact_urls", ArrayType(StringType()), False),
+            StructField("artifact_paths", ArrayType(StringType()), False),
+            StructField("processing_status", StringType(), False),
+            StructField("ingested_at", StringType(), False),
+        ]
+    )
+
+
+def _write_clean_events(  # pragma: no cover
+    spark: SparkSession,
+    clean_rows: list[dict[str, object]],
+    raw_events_table: str,
+) -> None:
+    """Write a list of CleanEvent dicts to the raw_events Delta table."""
+    schema = _clean_event_schema()
+    df = spark.createDataFrame(clean_rows, schema=schema)
+
+    parts = raw_events_table.split(".")
+    if len(parts) == 3:
+        catalog, db, _ = parts
+        spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{db}")
+
+    (
+        df.write.format("delta")
+        .mode("append")
+        .option("mergeSchema", "true")
+        .saveAsTable(raw_events_table)
+    )
+
+
+def run_list(  # pragma: no cover
+    scraped_pages_table: str,
+    search_results_table: str,
+    limit: int = 0,
+) -> list[str]:
+    """Read new scraped pages and emit their URLs as a Databricks task value.
+
+    Returns the list of URLs. Also sets the task value ``urls`` so that a
+    downstream ``for_each_task`` can iterate over them in parallel.
+    """
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    spark = SparkSession.builder.getOrCreate()
+
+    pages_df = spark.table(scraped_pages_table).filter(
+        F.col("processing_status") == ProcessingStatus.NEW
+    )
+
+    if limit > 0:
+        pages_df = pages_df.limit(limit)
+
+    urls: list[str] = [row["url"] for row in pages_df.select("url").collect()]
+    logger.info("New scraped pages to clean: {}", len(urls))
+
+    try:
+        from databricks.sdk.runtime import dbutils
+
+        dbutils.jobs.taskValues.set(key="urls", value=urls)
+        logger.info("Task value 'urls' set with {} entries", len(urls))
+    except ImportError:
+        logger.warning("dbutils not available — skipping task value set")
+
+    return urls
+
+
+def run_clean_one(  # pragma: no cover
+    url: str,
+    scraped_pages_table: str,
+    search_results_table: str,
+    raw_events_table: str,
+    *,
+    model: str,
+    client: OpenAI | None = None,
+    env: str = "dev",
+    languages: list[str] | None = None,
+    target_countries: list[str] | None = None,
+) -> None:
+    """Clean a single scraped page identified by *url* and append to raw_events.
+
+    Designed for use as the inner task of a Databricks ``for_each_task``.
+    """
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    spark = SparkSession.builder.getOrCreate()
+
+    pages_df = spark.table(scraped_pages_table).filter(F.col("url") == url)
+
+    # Join for language
+    if spark.catalog.tableExists(search_results_table):
+        lang_df = spark.table(search_results_table).select("url", "language")
+        pages_df = pages_df.join(lang_df, on="url", how="left")
+    else:
+        pages_df = pages_df.withColumn("language", F.lit("unknown"))
+
+    pages_df = pages_df.fillna({"language": "unknown"})
+
+    rows = pages_df.collect()
+    if not rows:
+        logger.warning("No scraped page found for URL: {}", url)
+        return
+
+    if client is None:
+        client = _build_openai_client()
+
+    clean_rows = []
+    for row in rows:
+        page = ScrapedPage(
+            fingerprint=row["fingerprint"],
+            url=row["url"],
+            title=row["title"] or "",
+            raw_text=row["raw_text"] or "",
+            artifact_urls=list(row["artifact_urls"] or []),
+            processing_status=ProcessingStatus(row["processing_status"]),
+            robots_allowed=row["robots_allowed"],
+            error=row["error"],
+        )
+        language = row["language"] or "unknown"
+        event = clean_page(
+            page,
+            language,
+            client,
+            model,
+            languages=languages,
+            target_countries=target_countries,
+        )
+        r = event.model_dump(mode="python")
+        r["url"] = str(r["url"])
+        r["ingested_at"] = str(r["ingested_at"])
+        clean_rows.append(r)
+
+    _write_clean_events(spark, clean_rows, raw_events_table)
+    logger.info("Wrote CleanEvent for {} to {}", url, raw_events_table)
 
 
 def run_clean(  # pragma: no cover
@@ -369,8 +609,22 @@ def run_clean(  # pragma: no cover
     model: str,
     client: OpenAI | None = None,
     env: str = "dev",
+    languages: list[str] | None = None,
+    target_countries: list[str] | None = None,
 ) -> int:
     """Read new ScrapedPage rows, clean them, and write CleanEvent rows to Delta.
+
+    Args:
+        scraped_pages_table: Fully-qualified Delta table for scraped pages.
+        search_results_table: Fully-qualified Delta table for search results
+            (used to look up language per URL).
+        raw_events_table: Fully-qualified Delta table to write CleanEvent rows to.
+        model: Databricks Foundation Model ID for LLM fallback extraction.
+        client: Pre-built OpenAI-compatible client (created from workspace token if None).
+        env: Deployment environment tag (dev/tst/acc/prd).
+        languages: BCP-47 codes from ArtLakeConfig.languages — passed to dateparser.
+        target_countries: ISO-3166-1 alpha-2 codes from ArtLakeConfig.target_countries
+            — used for TLD → country inference.
 
     Returns the number of events written.
     """
@@ -396,44 +650,7 @@ def run_clean(  # pragma: no cover
     logger.info("Cleaning {} new scraped pages", len(rows))
 
     if client is None:
-        from databricks.sdk import WorkspaceClient
-
-        w = WorkspaceClient()
-        token = w.tokens.create(lifetime_seconds=1200).token_value
-        host = w.config.host or ""
-        client = OpenAI(
-            api_key=token,
-            base_url=f"{host.rstrip('/')}/serving-endpoints",
-        )
-
-    from pyspark.sql.types import (
-        ArrayType,
-        FloatType,
-        StringType,
-        StructField,
-        StructType,
-        TimestampType,
-    )
-
-    schema = StructType(
-        [
-            StructField("title", StringType(), False),
-            StructField("description", StringType(), False),
-            StructField("date_start", TimestampType(), True),
-            StructField("date_end", TimestampType(), True),
-            StructField("location_text", StringType(), False),
-            StructField("lat", FloatType(), True),
-            StructField("lng", FloatType(), True),
-            StructField("country", StringType(), True),
-            StructField("language", StringType(), False),
-            StructField("source", StringType(), False),
-            StructField("url", StringType(), False),
-            StructField("artifact_urls", ArrayType(StringType()), False),
-            StructField("artifact_paths", ArrayType(StringType()), False),
-            StructField("processing_status", StringType(), False),
-            StructField("ingested_at", StringType(), False),
-        ]
-    )
+        client = _build_openai_client()
 
     clean_rows = []
     for row in rows:
@@ -448,7 +665,14 @@ def run_clean(  # pragma: no cover
             error=row["error"],
         )
         language = row["language"] or "unknown"
-        event = clean_page(page, language, client, model)
+        event = clean_page(
+            page,
+            language,
+            client,
+            model,
+            languages=languages,
+            target_countries=target_countries,
+        )
         # mode="python" preserves datetime objects — required for TimestampType columns
         r = event.model_dump(mode="python")
         r["url"] = str(r["url"])
@@ -459,28 +683,29 @@ def run_clean(  # pragma: no cover
         logger.info("No new pages to clean")
         return 0
 
-    df = spark.createDataFrame(clean_rows, schema=schema)
-
-    parts = raw_events_table.split(".")
-    if len(parts) == 3:
-        catalog, db, _ = parts
-        spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{db}")
-
-    (
-        df.write.format("delta")
-        .mode("append")
-        .option("mergeSchema", "true")
-        .saveAsTable(raw_events_table)
-    )
+    _write_clean_events(spark, clean_rows, raw_events_table)
     logger.info("Wrote {} CleanEvent rows to {}", len(clean_rows), raw_events_table)
     return len(clean_rows)
 
 
 def main() -> None:  # pragma: no cover
-    """Entry point for artlake-clean-events wheel task."""
+    """Entry point for artlake-clean-events wheel task.
+
+    Two modes:
+      list  — Read new scraped pages and emit their URLs as a Databricks task value
+              so a downstream for_each_task can iterate over them in parallel.
+      clean — Process a single URL (used as the for_each inner task).
+    """
     import argparse
 
     parser = argparse.ArgumentParser(description="ArtLake event cleaner")
+    parser.add_argument(
+        "--mode",
+        choices=["list", "clean"],
+        required=True,
+        help="'list' emits new page URLs as a task value; 'clean' processes one URL",
+    )
+    parser.add_argument("--url", help="URL to clean (required for --mode clean)")
     parser.add_argument(
         "--scraped-pages-table",
         default="artlake.staging.scraped_pages",
@@ -494,7 +719,7 @@ def main() -> None:  # pragma: no cover
     parser.add_argument(
         "--raw-events-table",
         default="artlake.bronze.raw_events",
-        help="Fully-qualified raw_events Delta table",
+        help="Fully-qualified raw_events Delta table (required for --mode clean)",
     )
     parser.add_argument(
         "--model",
@@ -502,16 +727,54 @@ def main() -> None:  # pragma: no cover
         help="Databricks Foundation Model for LLM fallback extraction",
     )
     parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Max URLs to emit in list mode (0 = no limit)",
+    )
+    parser.add_argument(
         "--env",
         default="dev",
         help="Deployment environment (dev/tst/acc/prd)",
     )
+    parser.add_argument(
+        "--languages",
+        nargs="+",
+        default=None,
+        metavar="LANG",
+        help=(
+            "BCP-47 language codes for date parsing, e.g. --languages en nl de fr. "
+            "Defaults to ['en'] when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--target-countries",
+        nargs="+",
+        default=None,
+        metavar="CODE",
+        help=(
+            "ISO-3166-1 alpha-2 country codes used for TLD → country inference, "
+            "e.g. --target-countries NL BE DE FR LU."
+        ),
+    )
     args = parser.parse_args()
 
-    run_clean(
-        scraped_pages_table=args.scraped_pages_table,
-        search_results_table=args.search_results_table,
-        raw_events_table=args.raw_events_table,
-        model=args.model,
-        env=args.env,
-    )
+    if args.mode == "list":
+        run_list(
+            scraped_pages_table=args.scraped_pages_table,
+            search_results_table=args.search_results_table,
+            limit=args.limit,
+        )
+    else:
+        if not args.url:
+            parser.error("--url is required for --mode clean")
+        run_clean_one(
+            url=args.url,
+            scraped_pages_table=args.scraped_pages_table,
+            search_results_table=args.search_results_table,
+            raw_events_table=args.raw_events_table,
+            model=args.model,
+            env=args.env,
+            languages=args.languages,
+            target_countries=args.target_countries,
+        )

--- a/src/artlake/clean/events.py
+++ b/src/artlake/clean/events.py
@@ -1,0 +1,485 @@
+"""Clean scraped pages into structured CleanEvent records.
+
+Entry point: artlake-clean-events
+
+Extraction funnel per page:
+  1. Parse dates rule-based (dateparser — multi-language, multi-format).
+  2. Flag outdated events early → write with processing_status='outdated'.
+  3. Extract title / description / location rule-based (regex heuristics).
+  4. LLM fallback for fields still missing after step 3.
+  5. Still incomplete after LLM → processing_status='requires_manual_validation'.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
+
+import backoff
+from loguru import logger
+from openai import OpenAI
+
+from artlake.models.event import CleanEvent, ProcessingStatus, ScrapedPage
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DATE_SEARCH_CHARS = 3000  # chars fed to dateparser.search
+_TEXT_TRUNCATE = 3000  # chars sent to LLM
+_DATE_HORIZON_DAYS = 730  # filter out dates > 2 years old (publication/copyright dates)
+_LANGUAGES = ["en", "nl", "de", "fr"]
+
+_LOCATION_RE = re.compile(
+    r"(?:^|\b)(?:Location|Venue|Address|Place|Locatie|Adresse|Adres|Ort|Lieu|Endroit)"
+    r"\s*:\s*(.+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+_EXTRACTION_SYSTEM = (
+    "You are a data extraction assistant. Extract structured event information "
+    "from web page text. Respond with ONLY a JSON object, no other text."
+)
+
+_EXTRACTION_PROMPT = """\
+Extract event information from the following text.
+
+Return ONLY a JSON object with these exact keys:
+{{
+  "title": "event title or null",
+  "description": "brief event description (max 500 chars) or null",
+  "date_start": "YYYY-MM-DD or null",
+  "date_end": "YYYY-MM-DD or null",
+  "location_text": "venue/address or null"
+}}
+
+Text:
+{text}"""
+
+
+# ---------------------------------------------------------------------------
+# Date parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_dates(text: str) -> tuple[datetime | None, datetime | None]:
+    """Extract start and end dates from raw text using dateparser.
+
+    Returns (date_start, date_end). Both may be None if no dates are found.
+    Dates more than two years in the past are discarded (copyright / publication noise).
+    """
+    from dateparser.search import search_dates  # type: ignore[import-untyped]
+
+    snippet = text[:_DATE_SEARCH_CHARS]
+    results = search_dates(
+        snippet,
+        languages=_LANGUAGES,
+        settings={"PREFER_DAY_OF_MONTH": "first", "RETURN_AS_TIMEZONE_AWARE": True},
+    )
+    if not results:
+        return None, None
+
+    cutoff = datetime.now(UTC) - timedelta(days=_DATE_HORIZON_DAYS)
+    seen: set[tuple[int, int, int]] = set()
+    dates: list[datetime] = []
+    for _, dt in results:
+        key = (dt.year, dt.month, dt.day)
+        if key not in seen and dt >= cutoff:
+            seen.add(key)
+            dates.append(dt)
+
+    dates.sort()
+
+    if not dates:
+        return None, None
+    if len(dates) == 1:
+        return dates[0], None
+    return dates[0], dates[-1]
+
+
+# ---------------------------------------------------------------------------
+# Outdated check
+# ---------------------------------------------------------------------------
+
+
+def is_outdated(date_start: datetime | None, date_end: datetime | None) -> bool:
+    """Return True if the event has already ended (or started, when no end date).
+
+    Events with no detected date are assumed ongoing → not outdated.
+    """
+    today = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    if date_end is not None:
+        return date_end < today
+    if date_start is not None:
+        return date_start < today
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Rule-based field extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_location(text: str) -> str | None:
+    match = _LOCATION_RE.search(text)
+    if match:
+        value = match.group(1).strip()
+        # Trim to first sentence or line
+        value = re.split(r"\.\s+|\n|\r|;\s+", value)[0].strip()
+        return value if value else None
+    return None
+
+
+def extract_fields_rule_based(page: ScrapedPage) -> dict[str, str | None]:
+    """Extract title, description, and location_text using heuristics.
+
+    Returns a dict with string-or-None values for each field.
+    """
+    title: str | None = page.title.strip() if page.title else None
+
+    # Fallback: first meaningful line of raw_text
+    if not title and page.raw_text:
+        for line in page.raw_text.splitlines():
+            stripped = line.strip()
+            if len(stripped) > 10:
+                title = stripped[:200]
+                break
+
+    description: str | None = None
+    if page.raw_text:
+        description = page.raw_text[:500].strip() or None
+
+    location_text = _extract_location(page.raw_text) if page.raw_text else None
+
+    return {"title": title, "description": description, "location_text": location_text}
+
+
+# ---------------------------------------------------------------------------
+# LLM fallback extraction
+# ---------------------------------------------------------------------------
+
+
+def _parse_json_response(content: str) -> dict[str, str | None]:
+    """Parse JSON from LLM response, stripping markdown fences if present."""
+    cleaned = re.sub(r"```(?:json)?\s*", "", content).strip()
+    result: dict[str, str | None] = json.loads(cleaned)
+    return result
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+def _call_extraction_llm(client: OpenAI, model: str, text: str) -> dict[str, str | None]:
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": _EXTRACTION_SYSTEM},
+            {"role": "user", "content": _EXTRACTION_PROMPT.format(text=text)},
+        ],
+        temperature=0.0,
+        max_tokens=512,
+    )
+    content = response.choices[0].message.content or ""
+    return _parse_json_response(content)
+
+
+def extract_fields_llm(
+    page: ScrapedPage, client: OpenAI, model: str
+) -> dict[str, str | None] | None:
+    """Call the LLM to extract structured fields. Returns None on failure."""
+    text = page.raw_text[:_TEXT_TRUNCATE] if page.raw_text else ""
+    if not text:
+        return None
+    try:
+        return _call_extraction_llm(client, model, text)
+    except Exception:
+        logger.warning("LLM extraction failed for {}", page.url)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Field completeness + merging
+# ---------------------------------------------------------------------------
+
+
+def _fields_complete(fields: dict[str, str | None]) -> bool:
+    return bool(
+        fields.get("title") and fields.get("description") and fields.get("location_text")
+    )
+
+
+def _merge_fields(
+    base: dict[str, str | None], override: dict[str, str | None]
+) -> dict[str, str | None]:
+    """Fill missing (None) fields in *base* from *override*."""
+    return {k: base.get(k) or override.get(k) for k in base}
+
+
+def _parse_llm_date(date_str: str | None) -> datetime | None:
+    """Parse a YYYY-MM-DD string from LLM output."""
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str).replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CleanEvent assembly
+# ---------------------------------------------------------------------------
+
+
+def _source_from_url(url: str) -> str:
+    return urlparse(url).netloc or str(url)
+
+
+def _make_clean_event(
+    page: ScrapedPage,
+    language: str,
+    date_start: datetime | None,
+    date_end: datetime | None,
+    fields: dict[str, str | None],
+    status: ProcessingStatus,
+) -> CleanEvent:
+    return CleanEvent(
+        title=fields.get("title") or page.title or str(page.url),
+        description=fields.get("description") or "",
+        date_start=date_start,
+        date_end=date_end,
+        location_text=fields.get("location_text") or "",
+        language=language,
+        source=_source_from_url(str(page.url)),
+        url=page.url,
+        artifact_urls=page.artifact_urls,
+        processing_status=status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def clean_page(
+    page: ScrapedPage,
+    language: str,
+    client: OpenAI,
+    model: str,
+) -> CleanEvent:
+    """Apply the extraction funnel to a single ScrapedPage and return a CleanEvent.
+
+    Funnel:
+      1. Parse dates rule-based.
+      2. Return early with status='outdated' if event has passed.
+      3. Extract fields rule-based.
+      4. LLM fallback for incomplete fields; re-check outdated after LLM date fill.
+      5. status='requires_manual_validation' if fields are still incomplete.
+    """
+    # Step 1 — rule-based date parsing
+    date_start, date_end = parse_dates(page.raw_text or "")
+
+    # Step 2 — filter outdated early (skip expensive steps below)
+    if is_outdated(date_start, date_end):
+        logger.info("Outdated event (rule-based dates): {}", page.url)
+        fields = extract_fields_rule_based(page)
+        return _make_clean_event(
+            page, language, date_start, date_end, fields, ProcessingStatus.OUTDATED
+        )
+
+    # Step 3 — rule-based field extraction
+    fields = extract_fields_rule_based(page)
+
+    # Step 4 — LLM fallback for missing fields
+    if not _fields_complete(fields):
+        logger.info("Falling back to LLM extraction for {}", page.url)
+        llm_result = extract_fields_llm(page, client, model)
+        if llm_result:
+            fields = _merge_fields(fields, llm_result)
+            # Fill dates from LLM if rule-based found none
+            if date_start is None:
+                date_start = _parse_llm_date(llm_result.get("date_start"))
+            if date_end is None:
+                date_end = _parse_llm_date(llm_result.get("date_end"))
+            # Re-check outdated now that LLM may have provided dates
+            if is_outdated(date_start, date_end):
+                logger.info("Outdated event (LLM dates): {}", page.url)
+                return _make_clean_event(
+                    page,
+                    language,
+                    date_start,
+                    date_end,
+                    fields,
+                    ProcessingStatus.OUTDATED,
+                )
+
+    # Step 5 — determine final status
+    status = (
+        ProcessingStatus.NEW
+        if _fields_complete(fields)
+        else ProcessingStatus.REQUIRES_MANUAL_VALIDATION
+    )
+    if status == ProcessingStatus.REQUIRES_MANUAL_VALIDATION:
+        logger.warning("Incomplete extraction, manual validation needed: {}", page.url)
+
+    return _make_clean_event(page, language, date_start, date_end, fields, status)
+
+
+# ---------------------------------------------------------------------------
+# Spark integration (pragma: no cover — tested via integration marker)
+# ---------------------------------------------------------------------------
+
+
+def run_clean(  # pragma: no cover
+    scraped_pages_table: str,
+    search_results_table: str,
+    raw_events_table: str,
+    *,
+    model: str,
+    client: OpenAI | None = None,
+    env: str = "dev",
+) -> int:
+    """Read new ScrapedPage rows, clean them, and write CleanEvent rows to Delta.
+
+    Returns the number of events written.
+    """
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    spark = SparkSession.builder.getOrCreate()
+
+    pages_df = spark.table(scraped_pages_table).filter(
+        F.col("processing_status") == ProcessingStatus.NEW
+    )
+
+    # Join with search_results to get language; default to 'unknown' if missing
+    if spark.catalog.tableExists(search_results_table):
+        lang_df = spark.table(search_results_table).select("url", "language")
+        pages_df = pages_df.join(lang_df, on="url", how="left")
+    else:
+        pages_df = pages_df.withColumn("language", F.lit("unknown"))
+
+    pages_df = pages_df.fillna({"language": "unknown"})
+
+    rows = pages_df.collect()
+    logger.info("Cleaning {} new scraped pages", len(rows))
+
+    if client is None:
+        from databricks.sdk import WorkspaceClient
+
+        w = WorkspaceClient()
+        token = w.tokens.create(lifetime_seconds=1200).token_value
+        host = w.config.host or ""
+        client = OpenAI(
+            api_key=token,
+            base_url=f"{host.rstrip('/')}/serving-endpoints",
+        )
+
+    from pyspark.sql.types import (
+        ArrayType,
+        FloatType,
+        StringType,
+        StructField,
+        StructType,
+        TimestampType,
+    )
+
+    schema = StructType(
+        [
+            StructField("title", StringType(), False),
+            StructField("description", StringType(), False),
+            StructField("date_start", TimestampType(), True),
+            StructField("date_end", TimestampType(), True),
+            StructField("location_text", StringType(), False),
+            StructField("lat", FloatType(), True),
+            StructField("lng", FloatType(), True),
+            StructField("country", StringType(), True),
+            StructField("language", StringType(), False),
+            StructField("source", StringType(), False),
+            StructField("url", StringType(), False),
+            StructField("artifact_urls", ArrayType(StringType()), False),
+            StructField("artifact_paths", ArrayType(StringType()), False),
+            StructField("processing_status", StringType(), False),
+            StructField("ingested_at", StringType(), False),
+        ]
+    )
+
+    clean_rows = []
+    for row in rows:
+        page = ScrapedPage(
+            fingerprint=row["fingerprint"],
+            url=row["url"],
+            title=row["title"] or "",
+            raw_text=row["raw_text"] or "",
+            artifact_urls=list(row["artifact_urls"] or []),
+            processing_status=ProcessingStatus(row["processing_status"]),
+            robots_allowed=row.get("robots_allowed"),
+            error=row.get("error"),
+        )
+        language = row.get("language") or "unknown"
+        event = clean_page(page, language, client, model)
+        r = event.model_dump(mode="json")
+        r["url"] = str(r["url"])
+        r["ingested_at"] = str(r["ingested_at"])
+        clean_rows.append(r)
+
+    if not clean_rows:
+        logger.info("No new pages to clean")
+        return 0
+
+    df = spark.createDataFrame(clean_rows, schema=schema)
+
+    parts = raw_events_table.split(".")
+    if len(parts) == 3:
+        catalog, db, _ = parts
+        spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{db}")
+
+    (
+        df.write.format("delta")
+        .mode("append")
+        .option("mergeSchema", "true")
+        .saveAsTable(raw_events_table)
+    )
+    logger.info("Wrote {} CleanEvent rows to {}", len(clean_rows), raw_events_table)
+    return len(clean_rows)
+
+
+def main() -> None:  # pragma: no cover
+    """Entry point for artlake-clean-events wheel task."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="ArtLake event cleaner")
+    parser.add_argument(
+        "--scraped-pages-table",
+        default="artlake.staging.scraped_pages",
+        help="Fully-qualified scraped_pages Delta table",
+    )
+    parser.add_argument(
+        "--search-results-table",
+        default="artlake.staging.search_results",
+        help="Fully-qualified search_results Delta table (for language lookup)",
+    )
+    parser.add_argument(
+        "--raw-events-table",
+        default="artlake.bronze.raw_events",
+        help="Fully-qualified raw_events Delta table",
+    )
+    parser.add_argument(
+        "--model",
+        default="databricks-meta-llama-3-3-70b-instruct",
+        help="Databricks Foundation Model for LLM fallback extraction",
+    )
+    parser.add_argument(
+        "--env",
+        default="dev",
+        help="Deployment environment (dev/tst/acc/prd)",
+    )
+    args = parser.parse_args()
+
+    run_clean(
+        scraped_pages_table=args.scraped_pages_table,
+        search_results_table=args.search_results_table,
+        raw_events_table=args.raw_events_table,
+        model=args.model,
+        env=args.env,
+    )

--- a/src/artlake/clean/events.py
+++ b/src/artlake/clean/events.py
@@ -17,6 +17,7 @@ import json
 import re
 import unicodedata
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -28,6 +29,7 @@ import backoff
 from loguru import logger
 from openai import OpenAI
 
+from artlake.clean.patterns import LanguagePatterns, build_field_re, load_patterns
 from artlake.models.event import CleanEvent, ProcessingStatus, ScrapedPage
 
 # ---------------------------------------------------------------------------
@@ -38,13 +40,6 @@ _DATE_SEARCH_CHARS = 3000  # chars fed to dateparser.search
 _TEXT_TRUNCATE = 3000  # chars sent to LLM
 _DATE_HORIZON_DAYS = 730  # filter out dates > 2 years old (publication/copyright noise)
 _DATE_FUTURE_DAYS = 365 * 100  # filter out dates > 100 years ahead (parser artefacts)
-
-
-_LOCATION_RE = re.compile(
-    r"(?:^|\b)(?:Location|Venue|Address|Place|Locatie|Adresse|Adres|Ort|Lieu|Endroit)"
-    r"\s*:\s*(.+)",
-    re.IGNORECASE | re.MULTILINE,
-)
 
 _EXTRACTION_SYSTEM = (
     "You are a data extraction assistant. Extract structured event information "
@@ -164,8 +159,9 @@ def _clean_title(title: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _extract_location(text: str) -> str | None:
-    match = _LOCATION_RE.search(text)
+def _extract_field(text: str, field_re: re.Pattern[str]) -> str | None:
+    """Extract the value following a labeled field (e.g. 'Location: Amsterdam')."""
+    match = field_re.search(text)
     if match:
         value = match.group(1).strip()
         # Trim to first sentence or line
@@ -174,12 +170,21 @@ def _extract_location(text: str) -> str | None:
     return None
 
 
-def extract_fields_rule_based(page: ScrapedPage) -> dict[str, str | None]:
+def extract_fields_rule_based(
+    page: ScrapedPage,
+    location_re: re.Pattern[str],
+    title_re: re.Pattern[str],
+) -> dict[str, str | None]:
     """Extract title, description, and location_text using heuristics.
 
     Returns a dict with string-or-None values for each field.
     All extracted strings are normalised (HTML entities decoded, unicode
     normalised, whitespace collapsed).
+
+    Args:
+        page: Scraped page to extract from.
+        location_re: Compiled regex built from patterns.location_keywords.
+        title_re: Compiled regex built from patterns.title_keywords.
     """
     title: str | None = _clean_title(page.title) if page.title else None
 
@@ -188,13 +193,17 @@ def extract_fields_rule_based(page: ScrapedPage) -> dict[str, str | None]:
     if page.raw_text and _looks_like_html(page.raw_text):
         return {"title": title, "description": None, "location_text": None}
 
-    # Fallback: first meaningful non-HTML line of raw_text
+    # Fallback title: try labeled field first ("Titel: Open Call"), then first line
     if not title and page.raw_text:
-        for line in page.raw_text.splitlines():
-            stripped = _normalize_text(line)
-            if len(stripped) > 10 and not stripped.startswith("<"):
-                title = _clean_title(stripped[:200])
-                break
+        raw_title = _extract_field(page.raw_text, title_re)
+        if raw_title:
+            title = _clean_title(raw_title[:200])
+        else:
+            for line in page.raw_text.splitlines():
+                stripped = _normalize_text(line)
+                if len(stripped) > 10 and not stripped.startswith("<"):
+                    title = _clean_title(stripped[:200])
+                    break
 
     description: str | None = None
     if page.raw_text:
@@ -203,7 +212,7 @@ def extract_fields_rule_based(page: ScrapedPage) -> dict[str, str | None]:
 
     location_text: str | None = None
     if page.raw_text:
-        raw_loc = _extract_location(page.raw_text)
+        raw_loc = _extract_field(page.raw_text, location_re)
         location_text = _normalize_text(raw_loc) if raw_loc else None
 
     return {"title": title, "description": description, "location_text": location_text}
@@ -340,9 +349,7 @@ def clean_page(
     language: str,
     client: OpenAI,
     model: str,
-    *,
-    languages: list[str] | None = None,
-    target_countries: list[str] | None = None,
+    patterns: LanguagePatterns,
 ) -> CleanEvent:
     """Apply the extraction funnel to a single ScrapedPage and return a CleanEvent.
 
@@ -358,20 +365,19 @@ def clean_page(
         language: BCP-47 language code for this page (from search_results join).
         client: OpenAI-compatible client pointed at Databricks Foundation Models.
         model: Model ID for LLM fallback extraction.
-        languages: Languages to pass to dateparser (from ArtLakeConfig.languages).
-            None lets dateparser auto-detect (slower).
-        target_countries: ISO-3166-1 alpha-2 codes for TLD → country inference
-            (from ArtLakeConfig.target_countries).
+        patterns: LanguagePatterns providing languages, target_countries, and
+            location_keywords for rule-based extraction.
     """
-    _target_countries = target_countries or []
+    location_re = build_field_re(patterns.location_keywords)
+    title_re = build_field_re(patterns.title_keywords)
 
     # Step 1 — rule-based date parsing
-    date_start, date_end = parse_dates(page.raw_text or "", languages)
+    date_start, date_end = parse_dates(page.raw_text or "", patterns.languages)
 
     # Step 2 — filter outdated early (skip expensive steps below)
     if is_outdated(date_start, date_end):
         logger.info("Outdated event (rule-based dates): {}", page.url)
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, location_re, title_re)
         return _make_clean_event(
             page,
             language,
@@ -379,11 +385,11 @@ def clean_page(
             date_end,
             fields,
             ProcessingStatus.OUTDATED,
-            _target_countries,
+            patterns.target_countries,
         )
 
     # Step 3 — rule-based field extraction
-    fields = extract_fields_rule_based(page)
+    fields = extract_fields_rule_based(page, location_re, title_re)
 
     # Step 4 — LLM fallback for missing fields
     if not _fields_complete(fields):
@@ -406,7 +412,7 @@ def clean_page(
                     date_end,
                     fields,
                     ProcessingStatus.OUTDATED,
-                    _target_countries,
+                    patterns.target_countries,
                 )
 
     # Step 5 — determine final status
@@ -419,7 +425,7 @@ def clean_page(
         logger.warning("Incomplete extraction, manual validation needed: {}", page.url)
 
     return _make_clean_event(
-        page, language, date_start, date_end, fields, status, _target_countries
+        page, language, date_start, date_end, fields, status, patterns.target_countries
     )
 
 
@@ -497,7 +503,7 @@ def _write_clean_events(  # pragma: no cover
 
 def run_list(  # pragma: no cover
     scraped_pages_table: str,
-    search_results_table: str,
+    patterns_path: Path,
     limit: int = 0,
 ) -> list[str]:
     """Read new scraped pages and emit their URLs as a Databricks task value.
@@ -509,6 +515,8 @@ def run_list(  # pragma: no cover
     from pyspark.sql import functions as F
 
     spark = SparkSession.builder.getOrCreate()
+
+    _ = load_patterns(patterns_path)  # validate patterns file is readable
 
     pages_df = spark.table(scraped_pages_table).filter(
         F.col("processing_status") == ProcessingStatus.NEW
@@ -536,12 +544,11 @@ def run_clean_one(  # pragma: no cover
     scraped_pages_table: str,
     search_results_table: str,
     raw_events_table: str,
+    patterns_path: Path,
     *,
     model: str,
     client: OpenAI | None = None,
     env: str = "dev",
-    languages: list[str] | None = None,
-    target_countries: list[str] | None = None,
 ) -> None:
     """Clean a single scraped page identified by *url* and append to raw_events.
 
@@ -551,6 +558,8 @@ def run_clean_one(  # pragma: no cover
     from pyspark.sql import functions as F
 
     spark = SparkSession.builder.getOrCreate()
+
+    patterns = load_patterns(patterns_path)
 
     pages_df = spark.table(scraped_pages_table).filter(F.col("url") == url)
 
@@ -584,14 +593,7 @@ def run_clean_one(  # pragma: no cover
             error=row["error"],
         )
         language = row["language"] or "unknown"
-        event = clean_page(
-            page,
-            language,
-            client,
-            model,
-            languages=languages,
-            target_countries=target_countries,
-        )
+        event = clean_page(page, language, client, model, patterns)
         r = event.model_dump(mode="python")
         r["url"] = str(r["url"])
         r["ingested_at"] = str(r["ingested_at"])
@@ -605,12 +607,11 @@ def run_clean(  # pragma: no cover
     scraped_pages_table: str,
     search_results_table: str,
     raw_events_table: str,
+    patterns_path: Path,
     *,
     model: str,
     client: OpenAI | None = None,
     env: str = "dev",
-    languages: list[str] | None = None,
-    target_countries: list[str] | None = None,
 ) -> int:
     """Read new ScrapedPage rows, clean them, and write CleanEvent rows to Delta.
 
@@ -619,12 +620,10 @@ def run_clean(  # pragma: no cover
         search_results_table: Fully-qualified Delta table for search results
             (used to look up language per URL).
         raw_events_table: Fully-qualified Delta table to write CleanEvent rows to.
+        patterns_path: Path to the language_patterns YAML file.
         model: Databricks Foundation Model ID for LLM fallback extraction.
         client: Pre-built OpenAI-compatible client (created from workspace token if None).
         env: Deployment environment tag (dev/tst/acc/prd).
-        languages: BCP-47 codes from ArtLakeConfig.languages — passed to dateparser.
-        target_countries: ISO-3166-1 alpha-2 codes from ArtLakeConfig.target_countries
-            — used for TLD → country inference.
 
     Returns the number of events written.
     """
@@ -632,6 +631,8 @@ def run_clean(  # pragma: no cover
     from pyspark.sql import functions as F
 
     spark = SparkSession.builder.getOrCreate()
+
+    patterns = load_patterns(patterns_path)
 
     pages_df = spark.table(scraped_pages_table).filter(
         F.col("processing_status") == ProcessingStatus.NEW
@@ -665,14 +666,7 @@ def run_clean(  # pragma: no cover
             error=row["error"],
         )
         language = row["language"] or "unknown"
-        event = clean_page(
-            page,
-            language,
-            client,
-            model,
-            languages=languages,
-            target_countries=target_countries,
-        )
+        event = clean_page(page, language, client, model, patterns)
         # mode="python" preserves datetime objects — required for TimestampType columns
         r = event.model_dump(mode="python")
         r["url"] = str(r["url"])
@@ -738,31 +732,17 @@ def main() -> None:  # pragma: no cover
         help="Deployment environment (dev/tst/acc/prd)",
     )
     parser.add_argument(
-        "--languages",
-        nargs="+",
-        default=None,
-        metavar="LANG",
-        help=(
-            "BCP-47 language codes for date parsing, e.g. --languages en nl de fr. "
-            "Defaults to ['en'] when omitted."
-        ),
-    )
-    parser.add_argument(
-        "--target-countries",
-        nargs="+",
-        default=None,
-        metavar="CODE",
-        help=(
-            "ISO-3166-1 alpha-2 country codes used for TLD → country inference, "
-            "e.g. --target-countries NL BE DE FR LU."
-        ),
+        "--language-patterns",
+        type=Path,
+        default=Path("config/output/language_patterns.yml"),
+        help="Path to the language_patterns YAML file",
     )
     args = parser.parse_args()
 
     if args.mode == "list":
         run_list(
             scraped_pages_table=args.scraped_pages_table,
-            search_results_table=args.search_results_table,
+            patterns_path=args.language_patterns,
             limit=args.limit,
         )
     else:
@@ -773,8 +753,7 @@ def main() -> None:  # pragma: no cover
             scraped_pages_table=args.scraped_pages_table,
             search_results_table=args.search_results_table,
             raw_events_table=args.raw_events_table,
+            patterns_path=args.language_patterns,
             model=args.model,
             env=args.env,
-            languages=args.languages,
-            target_countries=args.target_countries,
         )

--- a/src/artlake/clean/patterns.py
+++ b/src/artlake/clean/patterns.py
@@ -1,0 +1,220 @@
+"""Generate and load multilingual extraction patterns for art event pages.
+
+Entry point: artlake-generate-language-patterns
+
+The patterns YAML is derived from config/input/keywords.yml via LLM and written
+to config/output/language_patterns.yml. It drives all language-specific rule-based
+extraction in clean_events:
+  - languages       → passed to dateparser for date extraction
+  - target_countries → used for TLD → country inference
+  - title_keywords   → labels like "Titel:" used to find the event title in body text
+  - location_keywords → labels like "Locatie:" used to find the venue/address
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+import backoff
+import yaml
+from loguru import logger
+from openai import OpenAI
+from pydantic import BaseModel, ConfigDict
+
+from artlake.search.models import KeywordConfig
+
+_SYSTEM_PROMPT = (
+    "You are a multilingual data extraction assistant for art event web pages."
+)
+
+_USER_PROMPT_TEMPLATE = """\
+Given these language codes: {languages}
+
+Generate field labels that appear on art event web pages immediately before a colon,
+for two field types:
+
+1. title: labels identifying the event name
+   (e.g. "Title: Open Call" or "Titel: Kunstmarkt")
+2. location: labels identifying the venue or address
+   (e.g. "Location: Amsterdam" or "Adresse: Paris")
+
+Return ONLY a JSON object with this structure:
+{{
+  "title_keywords": {{
+    "en": ["Title", "Event", "Name"],
+    "nl": ["Titel", "Evenement", "Naam"],
+    ...
+  }},
+  "location_keywords": {{
+    "en": ["Location", "Venue", "Address", "Place"],
+    "nl": ["Locatie", "Adres"],
+    ...
+  }}
+}}
+
+Include English ("en") regardless of the input list. Keep each list concise (3-6 labels).
+Languages: {languages}"""
+
+
+class LanguagePatterns(BaseModel):
+    """Schema for config/output/language_patterns.yml.
+
+    Drives all language-specific behaviour in the clean_events pipeline.
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    generated_at: str
+    model: str
+    languages: list[str]
+    target_countries: list[str]
+    title_keywords: dict[str, list[str]]
+    location_keywords: dict[str, list[str]]
+
+
+def build_field_re(keywords: dict[str, list[str]]) -> re.Pattern[str]:
+    """Build a compiled colon-based extraction regex from per-language keyword lists.
+
+    Keywords are sorted by length descending so longer variants match first
+    (e.g. "Adresse" before "Adres").
+    """
+    all_keywords: list[str] = []
+    for kws in keywords.values():
+        all_keywords.extend(kws)
+    all_keywords.sort(key=len, reverse=True)
+    escaped = [re.escape(kw) for kw in all_keywords]
+    pattern = r"(?:^|\b)(?:" + "|".join(escaped) + r")\s*:\s*(.+)"
+    return re.compile(pattern, re.IGNORECASE | re.MULTILINE)
+
+
+def load_patterns(path: Path) -> LanguagePatterns:
+    """Load LanguagePatterns from a YAML file."""
+    raw = yaml.safe_load(path.read_text())
+    return LanguagePatterns(**raw)
+
+
+def _create_default_client() -> OpenAI:  # pragma: no cover
+    """Create an OpenAI client using Databricks workspace auth."""
+    from databricks.sdk import WorkspaceClient
+
+    w = WorkspaceClient()
+    host = w.config.host or ""
+    token = w.tokens.create(lifetime_seconds=1200).token_value
+    return OpenAI(
+        api_key=token,
+        base_url=f"{host.rstrip('/')}/serving-endpoints",
+    )
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+def _call_llm(
+    client: OpenAI,
+    model: str,
+    languages: list[str],
+) -> dict[str, dict[str, list[str]]]:
+    """Call the LLM to generate extraction keyword labels for the given languages.
+
+    Returns a dict with keys ``title_keywords`` and ``location_keywords``,
+    each mapping language code → list of field labels.
+    """
+    languages_str = ", ".join(languages)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": _USER_PROMPT_TEMPLATE.format(languages=languages_str),
+            },
+        ],
+        temperature=0.0,
+        max_tokens=512,
+    )
+    content = response.choices[0].message.content or ""
+    cleaned = re.sub(r"```(?:json)?\s*", "", content).strip()
+    result: dict[str, dict[str, list[str]]] = json.loads(cleaned)
+    return result
+
+
+def generate_patterns(
+    keywords_path: Path,
+    output_path: Path,
+    *,
+    model: str = "databricks-meta-llama-3-3-70b-instruct",
+    client: OpenAI | None = None,
+) -> LanguagePatterns:
+    """Read keywords.yml, call LLM to generate extraction patterns, write YAML.
+
+    Args:
+        keywords_path: Path to the input keywords YAML file.
+        output_path: Path where the generated language_patterns YAML will be written.
+        model: LLM model name for the Databricks serving endpoint.
+        client: Optional OpenAI client (injected for testing).
+
+    Returns:
+        The validated LanguagePatterns with all generated keywords.
+    """
+    raw = yaml.safe_load(keywords_path.read_text())
+    config = KeywordConfig(**raw)
+
+    target_countries = [country.code for country in config.countries]
+
+    lang_set: set[str] = {"en"}
+    for country in config.countries:
+        lang_set.update(country.languages)
+    languages = sorted(lang_set)
+
+    if client is None:
+        client = _create_default_client()  # pragma: no cover
+
+    logger.info("Generating extraction patterns for languages: {}", languages)
+    result = _call_llm(client, model, languages)
+
+    output = LanguagePatterns(
+        generated_at=datetime.now(tz=UTC).isoformat(),
+        model=model,
+        languages=languages,
+        target_countries=target_countries,
+        title_keywords=result.get("title_keywords", {}),
+        location_keywords=result.get("location_keywords", {}),
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        yaml.dump(
+            output.model_dump(),
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
+    )
+    logger.info("Wrote language patterns to {}", output_path)
+    return output
+
+
+def main() -> None:  # pragma: no cover
+    """Databricks wheel task entry point for artlake-generate-language-patterns."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate multilingual extraction patterns via LLM."
+    )
+    parser.add_argument(
+        "--keywords",
+        type=Path,
+        default=Path("config/input/keywords.yml"),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("config/output/language_patterns.yml"),
+    )
+    parser.add_argument(
+        "--model",
+        default="databricks-meta-llama-3-3-70b-instruct",
+    )
+    args = parser.parse_args()
+    generate_patterns(args.keywords, args.output, model=args.model)

--- a/src/artlake/models/event.py
+++ b/src/artlake/models/event.py
@@ -26,6 +26,7 @@ class RawEvent(BaseModel):
 
     model_config = ConfigDict(strict=True)
 
+    fingerprint: str
     url: HttpUrl
     title: str
     snippet: str
@@ -42,6 +43,7 @@ class CleanEvent(BaseModel):
 
     model_config = ConfigDict(strict=True)
 
+    fingerprint: str
     title: str
     description: str
     date_start: datetime | None = None

--- a/src/artlake/models/event.py
+++ b/src/artlake/models/event.py
@@ -18,6 +18,7 @@ class ProcessingStatus(StrEnum):
     DONE = "done"
     FAILED = "failed"
     OUTDATED = "outdated"
+    REQUIRES_MANUAL_VALIDATION = "requires_manual_validation"
 
 
 class RawEvent(BaseModel):

--- a/src/artlake/search/social.py
+++ b/src/artlake/search/social.py
@@ -10,6 +10,7 @@ import yaml
 from loguru import logger
 
 from artlake.models.event import RawEvent
+from artlake.scrape.pages import fingerprint as make_fingerprint
 from artlake.search.load import load_queries
 from artlake.search.models import SearchQuery
 from artlake.search.web import write_results
@@ -64,6 +65,7 @@ def _make_event(result: dict[str, str], language: str, source: str) -> RawEvent 
 
     try:
         return RawEvent(
+            fingerprint=make_fingerprint(url),
             url=url,  # type: ignore[arg-type]
             title=title,
             snippet=snippet,

--- a/src/artlake/search/web.py
+++ b/src/artlake/search/web.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from artlake.models.event import RawEvent
+from artlake.scrape.pages import fingerprint as make_fingerprint
 from artlake.search.load import load_queries
 from artlake.search.models import SearchQuery
 
@@ -35,6 +36,7 @@ def _make_event(result: dict[str, str], language: str) -> RawEvent | None:
 
     try:
         return RawEvent(
+            fingerprint=make_fingerprint(url),
             url=url,  # type: ignore[arg-type]
             title=title,
             snippet=snippet,
@@ -155,6 +157,7 @@ def write_results(events: list[RawEvent], table: str, env: str = "dev") -> None:
 
     rows = [
         {
+            "fingerprint": e.fingerprint,
             "url": str(e.url),
             "title": e.title,
             "snippet": e.snippet,

--- a/tests/test_clean_events.py
+++ b/tests/test_clean_events.py
@@ -9,8 +9,10 @@ import pytest
 from pydantic import HttpUrl
 
 from artlake.clean.events import (
+    _clean_title,
     _fields_complete,
     _merge_fields,
+    _normalize_text,
     _parse_llm_date,
     _source_from_url,
     clean_page,
@@ -137,6 +139,21 @@ class TestExtractFieldsRuleBased:
         fields = extract_fields_rule_based(page)
         assert fields["title"] == "Open Call 2025"
 
+    def test_strips_title_site_suffix(self) -> None:
+        page = _page(title="Open Call | Gallery Brussels", raw_text="Some text.")
+        fields = extract_fields_rule_based(page)
+        assert fields["title"] == "Open Call"
+
+    def test_normalizes_description_whitespace(self) -> None:
+        page = _page(raw_text="  Art   event  \n\t details  here  ")
+        fields = extract_fields_rule_based(page)
+        assert fields["description"] == "Art event details here"
+
+    def test_decodes_html_entities_in_description(self) -> None:
+        page = _page(raw_text="Open call for Art &amp; Design enthusiasts.")
+        fields = extract_fields_rule_based(page)
+        assert fields["description"] == "Open call for Art & Design enthusiasts."
+
     def test_fallback_to_first_line_when_no_title(self) -> None:
         page = _page(title="", raw_text="Art Market Brussels\nMore text here.")
         fields = extract_fields_rule_based(page)
@@ -239,6 +256,53 @@ class TestExtractFieldsLlm:
 # ---------------------------------------------------------------------------
 # _fields_complete / _merge_fields / helpers
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Text normalisation helpers
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeText:
+    def test_collapses_whitespace(self) -> None:
+        assert _normalize_text("hello   world\t\nfoo") == "hello world foo"
+
+    def test_decodes_html_entities(self) -> None:
+        assert _normalize_text("Art &amp; Culture") == "Art & Culture"
+        assert _normalize_text("open&#39;call") == "open'call"
+
+    def test_normalizes_unicode_nfkc(self) -> None:
+        # Ligature fi → f + i
+        assert _normalize_text("\ufb01ne art") == "fine art"
+
+    def test_strips_leading_trailing(self) -> None:
+        assert _normalize_text("  hello  ") == "hello"
+
+    def test_empty_string(self) -> None:
+        assert _normalize_text("") == ""
+
+
+class TestCleanTitle:
+    def test_strips_pipe_suffix(self) -> None:
+        assert _clean_title("Open Call | Gallery Brussels") == "Open Call"
+
+    def test_strips_dash_suffix(self) -> None:
+        assert _clean_title("Summer Exhibition - Stedelijk Museum") == "Summer Exhibition"
+
+    def test_strips_en_dash_suffix(self) -> None:
+        assert _clean_title("Art Fair – Amsterdam") == "Art Fair"
+
+    def test_strips_em_dash_suffix(self) -> None:
+        assert _clean_title("Residency — Berlin Art Week") == "Residency"
+
+    def test_no_suffix_unchanged(self) -> None:
+        assert _clean_title("Open Call for Artists") == "Open Call for Artists"
+
+    def test_normalizes_whitespace(self) -> None:
+        assert _clean_title("  Open   Call  ") == "Open Call"
+
+    def test_decodes_html_entities(self) -> None:
+        assert _clean_title("Art &amp; Design | Museum") == "Art & Design"
 
 
 class TestHelpers:

--- a/tests/test_clean_events.py
+++ b/tests/test_clean_events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -523,5 +524,6 @@ class TestCleanEventsIntegration:
             scraped_pages_table="artlake.staging.scraped_pages",
             search_results_table="artlake.staging.search_results",
             raw_events_table="artlake.bronze.raw_events",
+            patterns_path=Path("config/output/language_patterns.yml"),
             model="databricks-meta-llama-3-3-70b-instruct",
         )

--- a/tests/test_clean_events.py
+++ b/tests/test_clean_events.py
@@ -23,7 +23,29 @@ from artlake.clean.events import (
     is_outdated,
     parse_dates,
 )
+from artlake.clean.patterns import LanguagePatterns, build_field_re
 from artlake.models.event import ProcessingStatus, ScrapedPage
+
+_TEST_PATTERNS = LanguagePatterns(
+    generated_at="2026-01-01T00:00:00+00:00",
+    model="test",
+    languages=["en", "nl", "de", "fr"],
+    target_countries=["NL", "BE", "DE", "FR", "LU"],
+    title_keywords={
+        "en": ["Title", "Event", "Name"],
+        "nl": ["Titel", "Evenement", "Naam"],
+        "de": ["Titel", "Veranstaltung"],
+        "fr": ["Titre", "Événement", "Nom"],
+    },
+    location_keywords={
+        "en": ["Location", "Venue", "Address", "Place"],
+        "nl": ["Locatie", "Adres"],
+        "de": ["Ort", "Adresse"],
+        "fr": ["Lieu", "Adresse", "Endroit"],
+    },
+)
+_TEST_LOCATION_RE = build_field_re(_TEST_PATTERNS.location_keywords)
+_TEST_TITLE_RE = build_field_re(_TEST_PATTERNS.title_keywords)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -146,64 +168,69 @@ class TestIsOutdated:
 class TestExtractFieldsRuleBased:
     def test_uses_page_title(self) -> None:
         page = _page(title="Open Call 2025", raw_text="Some description text here.")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["title"] == "Open Call 2025"
 
     def test_strips_title_site_suffix(self) -> None:
         page = _page(title="Open Call | Gallery Brussels", raw_text="Some text.")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["title"] == "Open Call"
 
     def test_normalizes_description_whitespace(self) -> None:
         page = _page(raw_text="  Art   event  \n\t details  here  ")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["description"] == "Art event details here"
 
     def test_decodes_html_entities_in_description(self) -> None:
         page = _page(raw_text="Open call for Art &amp; Design enthusiasts.")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["description"] == "Open call for Art & Design enthusiasts."
+
+    def test_extracts_title_from_labeled_field(self) -> None:
+        page = _page(title="", raw_text="Titel: Kunstmarkt Amsterdam\nMore text here.")
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
+        assert fields["title"] == "Kunstmarkt Amsterdam"
 
     def test_fallback_to_first_line_when_no_title(self) -> None:
         page = _page(title="", raw_text="Art Market Brussels\nMore text here.")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["title"] == "Art Market Brussels"
 
     def test_extracts_description_from_raw_text(self) -> None:
         page = _page(raw_text="A" * 600)
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["description"] is not None
         assert len(fields["description"]) <= 500
 
     def test_extracts_location_with_keyword(self) -> None:
         page = _page(raw_text="Event details\nLocation: Antwerp, Belgium\nMore info.")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["location_text"] == "Antwerp, Belgium"
 
     def test_extracts_venue_keyword(self) -> None:
         page = _page(raw_text="Venue: Stedelijk Museum Amsterdam")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["location_text"] == "Stedelijk Museum Amsterdam"
 
     def test_extracts_adresse_keyword(self) -> None:
         page = _page(raw_text="Adresse: Rue du Louvre 75, Paris")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["location_text"] == "Rue du Louvre 75, Paris"
 
     def test_no_location_returns_none(self) -> None:
         page = _page(raw_text="Join us for the event. Great fun ahead.")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["location_text"] is None
 
     def test_html_raw_text_forces_none_fields(self) -> None:
         page = _page(raw_text="<!DOCTYPE html><html><body>Maintenance</body></html>")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["description"] is None
         assert fields["location_text"] is None
 
     def test_empty_page(self) -> None:
         page = _page(title="", raw_text="")
-        fields = extract_fields_rule_based(page)
+        fields = extract_fields_rule_based(page, _TEST_LOCATION_RE, _TEST_TITLE_RE)
         assert fields["title"] is None
         assert fields["description"] is None
         assert fields["location_text"] is None
@@ -395,7 +422,7 @@ class TestCleanPage:
             raw_text=f"Event on {past_date}. Location: Amsterdam.",
         )
         client = MagicMock()
-        event = clean_page(page, "en", client, "test-model")
+        event = clean_page(page, "en", client, "test-model", _TEST_PATTERNS)
         assert event.processing_status == ProcessingStatus.OUTDATED
         client.chat.completions.create.assert_not_called()
 
@@ -405,7 +432,7 @@ class TestCleanPage:
             raw_text="Great exhibition. Location: Brussels, Belgium. Apply by 2099-08-01.",  # noqa: E501
         )
         client = MagicMock()
-        event = clean_page(page, "en", client, "test-model")
+        event = clean_page(page, "en", client, "test-model", _TEST_PATTERNS)
         assert event.processing_status == ProcessingStatus.NEW
         assert event.title == "Summer Open Call"
         assert event.location_text == "Brussels, Belgium"
@@ -418,7 +445,7 @@ class TestCleanPage:
         )
         client = self._client_with(payload)
 
-        event = clean_page(page, "nl", client, "test-model")
+        event = clean_page(page, "nl", client, "test-model", _TEST_PATTERNS)
 
         client.chat.completions.create.assert_called_once()
         assert event.location_text == "Rotterdam"
@@ -429,7 +456,7 @@ class TestCleanPage:
         client = MagicMock()
         client.chat.completions.create.side_effect = Exception("LLM down")
 
-        event = clean_page(page, "en", client, "test-model")
+        event = clean_page(page, "en", client, "test-model", _TEST_PATTERNS)
 
         assert event.processing_status == ProcessingStatus.REQUIRES_MANUAL_VALIDATION
 
@@ -445,7 +472,7 @@ class TestCleanPage:
         )
         client = self._client_with(payload)
 
-        event = clean_page(page, "de", client, "test-model")
+        event = clean_page(page, "de", client, "test-model", _TEST_PATTERNS)
 
         assert event.processing_status == ProcessingStatus.OUTDATED
 
@@ -456,7 +483,7 @@ class TestCleanPage:
             artifact_urls=["https://example.com/poster.pdf"],
         )
         client = MagicMock()
-        event = clean_page(page, "en", client, "test-model")
+        event = clean_page(page, "en", client, "test-model", _TEST_PATTERNS)
         assert "https://example.com/poster.pdf" in event.artifact_urls
 
     def test_no_date_event_is_not_outdated(self) -> None:
@@ -475,7 +502,7 @@ class TestCleanPage:
                 )
             )
         ]
-        event = clean_page(page, "fr", client, "test-model")
+        event = clean_page(page, "fr", client, "test-model", _TEST_PATTERNS)
         assert event.processing_status != ProcessingStatus.OUTDATED
 
 

--- a/tests/test_clean_events.py
+++ b/tests/test_clean_events.py
@@ -10,7 +10,9 @@ from pydantic import HttpUrl
 
 from artlake.clean.events import (
     _clean_title,
+    _country_from_url,
     _fields_complete,
+    _looks_like_html,
     _merge_fields,
     _normalize_text,
     _parse_llm_date,
@@ -96,6 +98,14 @@ class TestParseDates:
         # 1985 should be filtered out as > 2 years old
         assert start is not None
         assert start.year == 2099
+
+    def test_filters_absurd_future_dates(self) -> None:
+        # Year 9816 (dateparser artefact) should be filtered out
+        text = "Event on 2027-06-01. Copyright 9816."
+        start, end = parse_dates(text)
+        assert start is not None
+        assert start.year == 2027
+        assert end is None
 
     def test_empty_text(self) -> None:
         start, end = parse_dates("")
@@ -183,6 +193,12 @@ class TestExtractFieldsRuleBased:
     def test_no_location_returns_none(self) -> None:
         page = _page(raw_text="Join us for the event. Great fun ahead.")
         fields = extract_fields_rule_based(page)
+        assert fields["location_text"] is None
+
+    def test_html_raw_text_forces_none_fields(self) -> None:
+        page = _page(raw_text="<!DOCTYPE html><html><body>Maintenance</body></html>")
+        fields = extract_fields_rule_based(page)
+        assert fields["description"] is None
         assert fields["location_text"] is None
 
     def test_empty_page(self) -> None:
@@ -333,6 +349,29 @@ class TestHelpers:
 
     def test_source_from_url(self) -> None:
         assert _source_from_url("https://example.com/event/123") == "example.com"
+
+    def test_country_from_url_known_tld(self) -> None:
+        countries = ["NL", "BE", "DE", "FR", "LU"]
+        assert _country_from_url("https://gallery.nl/event", countries) == "NL"
+        assert _country_from_url("https://museum.be/expo", countries) == "BE"
+        assert _country_from_url("https://kunst.de/aufruf", countries) == "DE"
+        assert _country_from_url("https://art.fr/appel", countries) == "FR"
+        assert _country_from_url("https://opc-luxembourg.lu/de/", countries) == "LU"
+
+    def test_country_from_url_unknown_tld(self) -> None:
+        countries = ["NL", "BE", "DE", "FR", "LU"]
+        assert _country_from_url("https://example.com/event", countries) is None
+        assert _country_from_url("https://artsy.org/show", countries) is None
+
+    def test_looks_like_html_doctype(self) -> None:
+        assert _looks_like_html("<!DOCTYPE html><html><body>text</body></html>")
+
+    def test_looks_like_html_tag(self) -> None:
+        assert _looks_like_html("<html lang='fr'><head></head></html>")
+
+    def test_looks_like_html_false_for_plain_text(self) -> None:
+        assert not _looks_like_html("Open call for artists in Brussels.")
+        assert not _looks_like_html("Location: Amsterdam")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_clean_events.py
+++ b/tests/test_clean_events.py
@@ -1,0 +1,397 @@
+"""Tests for clean/events.py."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import HttpUrl
+
+from artlake.clean.events import (
+    _fields_complete,
+    _merge_fields,
+    _parse_llm_date,
+    _source_from_url,
+    clean_page,
+    extract_fields_llm,
+    extract_fields_rule_based,
+    is_outdated,
+    parse_dates,
+)
+from artlake.models.event import ProcessingStatus, ScrapedPage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _page(
+    raw_text: str = "",
+    title: str = "",
+    artifact_urls: list[str] | None = None,
+) -> ScrapedPage:
+    return ScrapedPage(
+        fingerprint="abc123",
+        url=HttpUrl("https://example.com/event"),
+        title=title,
+        raw_text=raw_text,
+        artifact_urls=artifact_urls or [],
+        processing_status=ProcessingStatus.NEW,
+    )
+
+
+def _future(days: int = 30) -> datetime:
+    return datetime.now(UTC) + timedelta(days=days)
+
+
+def _past(days: int = 30) -> datetime:
+    return datetime.now(UTC) - timedelta(days=days)
+
+
+# ---------------------------------------------------------------------------
+# parse_dates
+# ---------------------------------------------------------------------------
+
+
+class TestParseDates:
+    def test_iso_format(self) -> None:
+        text = "The event runs from 2099-06-01 to 2099-06-15."
+        start, end = parse_dates(text)
+        assert start is not None
+        assert end is not None
+        assert start.year == 2099
+        assert start.month == 6
+        assert start.day == 1
+
+    def test_european_format(self) -> None:
+        text = "Deadline: 15/08/2099"
+        start, end = parse_dates(text)
+        assert start is not None
+        assert start.year == 2099
+
+    def test_natural_language_english(self) -> None:
+        text = "Join us on August 20, 2099 for the opening."
+        start, _ = parse_dates(text)
+        assert start is not None
+        assert start.year == 2099
+
+    def test_returns_none_when_no_dates(self) -> None:
+        text = "Welcome to our art gallery. No dates mentioned here."
+        start, end = parse_dates(text)
+        assert start is None
+        assert end is None
+
+    def test_single_date_returns_none_end(self) -> None:
+        text = "Event on 2099-03-15."
+        start, end = parse_dates(text)
+        assert start is not None
+        assert end is None
+
+    def test_filters_old_dates(self) -> None:
+        text = "Founded in 1985. Next event: 2099-05-01."
+        start, end = parse_dates(text)
+        # 1985 should be filtered out as > 2 years old
+        assert start is not None
+        assert start.year == 2099
+
+    def test_empty_text(self) -> None:
+        start, end = parse_dates("")
+        assert start is None
+        assert end is None
+
+
+# ---------------------------------------------------------------------------
+# is_outdated
+# ---------------------------------------------------------------------------
+
+
+class TestIsOutdated:
+    def test_past_end_date(self) -> None:
+        assert is_outdated(_past(10), None) is True
+
+    def test_past_end_date_with_range(self) -> None:
+        assert is_outdated(_past(20), _past(5)) is True
+
+    def test_future_end_date(self) -> None:
+        assert is_outdated(_past(5), _future(10)) is False
+
+    def test_future_start_no_end(self) -> None:
+        assert is_outdated(_future(5), None) is False
+
+    def test_past_start_no_end(self) -> None:
+        assert is_outdated(_past(5), None) is True
+
+    def test_no_dates(self) -> None:
+        assert is_outdated(None, None) is False
+
+
+# ---------------------------------------------------------------------------
+# extract_fields_rule_based
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFieldsRuleBased:
+    def test_uses_page_title(self) -> None:
+        page = _page(title="Open Call 2025", raw_text="Some description text here.")
+        fields = extract_fields_rule_based(page)
+        assert fields["title"] == "Open Call 2025"
+
+    def test_fallback_to_first_line_when_no_title(self) -> None:
+        page = _page(title="", raw_text="Art Market Brussels\nMore text here.")
+        fields = extract_fields_rule_based(page)
+        assert fields["title"] == "Art Market Brussels"
+
+    def test_extracts_description_from_raw_text(self) -> None:
+        page = _page(raw_text="A" * 600)
+        fields = extract_fields_rule_based(page)
+        assert fields["description"] is not None
+        assert len(fields["description"]) <= 500
+
+    def test_extracts_location_with_keyword(self) -> None:
+        page = _page(raw_text="Event details\nLocation: Antwerp, Belgium\nMore info.")
+        fields = extract_fields_rule_based(page)
+        assert fields["location_text"] == "Antwerp, Belgium"
+
+    def test_extracts_venue_keyword(self) -> None:
+        page = _page(raw_text="Venue: Stedelijk Museum Amsterdam")
+        fields = extract_fields_rule_based(page)
+        assert fields["location_text"] == "Stedelijk Museum Amsterdam"
+
+    def test_extracts_adresse_keyword(self) -> None:
+        page = _page(raw_text="Adresse: Rue du Louvre 75, Paris")
+        fields = extract_fields_rule_based(page)
+        assert fields["location_text"] == "Rue du Louvre 75, Paris"
+
+    def test_no_location_returns_none(self) -> None:
+        page = _page(raw_text="Join us for the event. Great fun ahead.")
+        fields = extract_fields_rule_based(page)
+        assert fields["location_text"] is None
+
+    def test_empty_page(self) -> None:
+        page = _page(title="", raw_text="")
+        fields = extract_fields_rule_based(page)
+        assert fields["title"] is None
+        assert fields["description"] is None
+        assert fields["location_text"] is None
+
+
+# ---------------------------------------------------------------------------
+# extract_fields_llm
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFieldsLlm:
+    def _mock_client(self, response_json: str) -> MagicMock:
+        client = MagicMock()
+        msg = MagicMock()
+        msg.content = response_json
+        client.chat.completions.create.return_value.choices = [MagicMock(message=msg)]
+        return client
+
+    def test_returns_parsed_fields(self) -> None:
+        payload = (
+            '{"title": "Open Call", "description": "Nice event",'
+            ' "date_start": "2099-06-01", "date_end": null, "location_text": "Brussels"}'
+        )
+        client = self._mock_client(payload)
+        page = _page(raw_text="Some text about an open call in Brussels.")
+
+        result = extract_fields_llm(page, client, "test-model")
+
+        assert result is not None
+        assert result["title"] == "Open Call"
+        assert result["location_text"] == "Brussels"
+
+    def test_handles_markdown_fences(self) -> None:
+        payload = (
+            "```json\n"
+            '{"title": "Expo", "description": "Art show",'
+            ' "date_start": null, "date_end": null, "location_text": "Paris"}'
+            "\n```"
+        )
+        client = self._mock_client(payload)
+        page = _page(raw_text="Art exposition in Paris.")
+
+        result = extract_fields_llm(page, client, "test-model")
+
+        assert result is not None
+        assert result["title"] == "Expo"
+
+    def test_returns_none_on_llm_error(self) -> None:
+        client = MagicMock()
+        client.chat.completions.create.side_effect = Exception("API error")
+        page = _page(raw_text="Some text.")
+
+        result = extract_fields_llm(page, client, "test-model")
+
+        assert result is None
+
+    def test_returns_none_for_empty_page(self) -> None:
+        client = MagicMock()
+        page = _page(raw_text="")
+
+        result = extract_fields_llm(page, client, "test-model")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _fields_complete / _merge_fields / helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_fields_complete_all_present(self) -> None:
+        assert _fields_complete({"title": "T", "description": "D", "location_text": "L"})
+
+    def test_fields_complete_missing_one(self) -> None:
+        assert not _fields_complete(
+            {"title": "T", "description": "D", "location_text": None}
+        )
+
+    def test_merge_fills_none_from_override(self) -> None:
+        base = {"title": "T", "description": None, "location_text": None}
+        override = {"title": "Ignored", "description": "D2", "location_text": "L2"}
+        merged = _merge_fields(base, override)
+        assert merged["title"] == "T"
+        assert merged["description"] == "D2"
+        assert merged["location_text"] == "L2"
+
+    def test_parse_llm_date_valid(self) -> None:
+        dt = _parse_llm_date("2099-06-01")
+        assert dt is not None
+        assert dt.year == 2099
+
+    def test_parse_llm_date_invalid(self) -> None:
+        assert _parse_llm_date("not-a-date") is None
+        assert _parse_llm_date(None) is None
+
+    def test_source_from_url(self) -> None:
+        assert _source_from_url("https://example.com/event/123") == "example.com"
+
+
+# ---------------------------------------------------------------------------
+# clean_page — integration of the full funnel
+# ---------------------------------------------------------------------------
+
+
+class TestCleanPage:
+    def _client_with(self, payload: str) -> MagicMock:
+        client = MagicMock()
+        msg = MagicMock()
+        msg.content = payload
+        client.chat.completions.create.return_value.choices = [MagicMock(message=msg)]
+        return client
+
+    def test_outdated_event_returns_outdated_status(self) -> None:
+        # Past date in text → funnel exits early with outdated
+        past_date = (_past(10)).strftime("%Y-%m-%d")
+        page = _page(
+            title="Old Show",
+            raw_text=f"Event on {past_date}. Location: Amsterdam.",
+        )
+        client = MagicMock()
+        event = clean_page(page, "en", client, "test-model")
+        assert event.processing_status == ProcessingStatus.OUTDATED
+        client.chat.completions.create.assert_not_called()
+
+    def test_complete_fields_returns_new_status(self) -> None:
+        page = _page(
+            title="Summer Open Call",
+            raw_text="Great exhibition. Location: Brussels, Belgium. Apply by 2099-08-01.",  # noqa: E501
+        )
+        client = MagicMock()
+        event = clean_page(page, "en", client, "test-model")
+        assert event.processing_status == ProcessingStatus.NEW
+        assert event.title == "Summer Open Call"
+        assert event.location_text == "Brussels, Belgium"
+
+    def test_llm_fallback_called_when_fields_incomplete(self) -> None:
+        page = _page(title="Show", raw_text="Some vague text with no location.")
+        payload = (
+            '{"title": "Show", "description": "Nice event.",'
+            ' "date_start": null, "date_end": null, "location_text": "Rotterdam"}'
+        )
+        client = self._client_with(payload)
+
+        event = clean_page(page, "nl", client, "test-model")
+
+        client.chat.completions.create.assert_called_once()
+        assert event.location_text == "Rotterdam"
+        assert event.processing_status == ProcessingStatus.NEW
+
+    def test_requires_manual_validation_when_llm_also_fails(self) -> None:
+        page = _page(title="Show", raw_text="Some vague text.")
+        client = MagicMock()
+        client.chat.completions.create.side_effect = Exception("LLM down")
+
+        event = clean_page(page, "en", client, "test-model")
+
+        assert event.processing_status == ProcessingStatus.REQUIRES_MANUAL_VALIDATION
+
+    def test_llm_date_triggers_outdated_recheck(self) -> None:
+        # No dates in text (rule-based finds nothing), LLM returns past date
+        past_date = _past(5).strftime("%Y-%m-%d")
+        page = _page(
+            title="Old", raw_text="Some vague text without clear dates no location."
+        )
+        payload = (
+            f'{{"title": "Old", "description": "Past event.",'
+            f' "date_start": "{past_date}", "date_end": null, "location_text": "Berlin"}}'
+        )
+        client = self._client_with(payload)
+
+        event = clean_page(page, "de", client, "test-model")
+
+        assert event.processing_status == ProcessingStatus.OUTDATED
+
+    def test_copies_artifact_urls(self) -> None:
+        page = _page(
+            title="Show",
+            raw_text="Location: Amsterdam. Great art event happening in 2099.",
+            artifact_urls=["https://example.com/poster.pdf"],
+        )
+        client = MagicMock()
+        event = clean_page(page, "en", client, "test-model")
+        assert "https://example.com/poster.pdf" in event.artifact_urls
+
+    def test_no_date_event_is_not_outdated(self) -> None:
+        page = _page(
+            title="Ongoing Show",
+            raw_text="An ongoing exhibition. Location: Paris.",
+        )
+        client = MagicMock()
+        client.chat.completions.create.return_value.choices = [
+            MagicMock(
+                message=MagicMock(
+                    content=(
+                        '{"title": "Ongoing Show", "description": "Ongoing.",'
+                        ' "date_start": null, "date_end": null, "location_text": "Paris"}'
+                    )
+                )
+            )
+        ]
+        event = clean_page(page, "fr", client, "test-model")
+        assert event.processing_status != ProcessingStatus.OUTDATED
+
+
+# ---------------------------------------------------------------------------
+# Integration test (requires live Databricks)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestCleanEventsIntegration:
+    def test_delta_write(self) -> None:
+        """Write a single CleanEvent to bronze.raw_events and verify row count."""
+        from artlake.clean.events import run_clean
+
+        # Integration test: validates schema compatibility and Delta write
+        # Requires a Databricks workspace with artlake catalog.
+        run_clean(
+            scraped_pages_table="artlake.staging.scraped_pages",
+            search_results_table="artlake.staging.search_results",
+            raw_events_table="artlake.bronze.raw_events",
+            model="databricks-meta-llama-3-3-70b-instruct",
+        )

--- a/tests/test_clean_patterns.py
+++ b/tests/test_clean_patterns.py
@@ -1,0 +1,107 @@
+"""Tests for clean/patterns.py."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+from artlake.clean.patterns import (
+    build_field_re,
+    generate_patterns,
+    load_patterns,
+)
+
+_PAYLOAD = (
+    '{"title_keywords": {"en": ["Title", "Name"], "nl": ["Titel", "Naam"]},'
+    ' "location_keywords": {"en": ["Location", "Venue"], "nl": ["Locatie"]}}'
+)
+
+
+class TestBuildFieldRe:
+    def test_matches_english_keyword(self) -> None:
+        field_re = build_field_re({"en": ["Location", "Venue"]})
+        m = field_re.search("Location: Amsterdam")
+        assert m is not None
+        assert m.group(1).strip() == "Amsterdam"
+
+    def test_longer_keyword_wins(self) -> None:
+        # "Adresse" must match before "Adres" to avoid partial match
+        field_re = build_field_re({"nl": ["Adres"], "de": ["Adresse"]})
+        m = field_re.search("Adresse: Paris")
+        assert m is not None
+        assert "Paris" in m.group(1)
+
+    def test_no_match_without_colon(self) -> None:
+        field_re = build_field_re({"en": ["Location"]})
+        assert field_re.search("The location is Amsterdam") is None
+
+    def test_multilingual(self) -> None:
+        field_re = build_field_re({"en": ["Location"], "nl": ["Locatie"]})
+        assert field_re.search("Locatie: Rotterdam") is not None
+
+    def test_matches_title_keyword(self) -> None:
+        field_re = build_field_re({"en": ["Title", "Name"], "nl": ["Titel"]})
+        m = field_re.search("Titel: Kunstmarkt Amsterdam")
+        assert m is not None
+        assert "Kunstmarkt Amsterdam" in m.group(1)
+
+
+class TestLoadPatterns:
+    def test_loads_valid_yaml(self, tmp_path: Path) -> None:
+        data = {
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "model": "test-model",
+            "languages": ["en", "nl"],
+            "target_countries": ["NL"],
+            "title_keywords": {"en": ["Title"], "nl": ["Titel"]},
+            "location_keywords": {"en": ["Location"], "nl": ["Locatie"]},
+        }
+        path = tmp_path / "patterns.yml"
+        path.write_text(yaml.dump(data))
+        patterns = load_patterns(path)
+        assert patterns.languages == ["en", "nl"]
+        assert patterns.target_countries == ["NL"]
+        assert "en" in patterns.title_keywords
+        assert "en" in patterns.location_keywords
+
+
+class TestGeneratePatterns:
+    def _mock_client(self, response_json: str) -> MagicMock:
+        client = MagicMock()
+        msg = MagicMock()
+        msg.content = response_json
+        client.chat.completions.create.return_value.choices = [MagicMock(message=msg)]
+        return client
+
+    def test_generates_and_writes(self, tmp_path: Path) -> None:
+        keywords_yml = tmp_path / "keywords.yml"
+        keywords_yml.write_text(
+            "keywords:\n  - art\ncountries:\n"
+            "  - code: NL\n    name: Netherlands\n    languages: [nl]\n"
+        )
+        output_path = tmp_path / "output" / "language_patterns.yml"
+        client = self._mock_client(_PAYLOAD)
+
+        patterns = generate_patterns(
+            keywords_yml, output_path, model="test-model", client=client
+        )
+
+        assert output_path.exists()
+        assert "en" in patterns.languages
+        assert "nl" in patterns.languages
+        assert "NL" in patterns.target_countries
+        assert "Title" in patterns.title_keywords["en"]
+        assert "Location" in patterns.location_keywords["en"]
+
+    def test_always_includes_english(self, tmp_path: Path) -> None:
+        keywords_yml = tmp_path / "keywords.yml"
+        keywords_yml.write_text(
+            "keywords:\n  - art\ncountries:\n"
+            "  - code: NL\n    name: Netherlands\n    languages: [nl]\n"
+        )
+        output_path = tmp_path / "patterns.yml"
+        client = self._mock_client(_PAYLOAD)
+        patterns = generate_patterns(
+            keywords_yml, output_path, model="test", client=client
+        )
+        assert "en" in patterns.languages

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,6 +23,7 @@ from artlake.models import (
 class TestRawEvent:
     def test_valid_minimal(self) -> None:
         event = RawEvent(
+            fingerprint="abc123",
             url="https://example.com/event",
             title="Open Call",
             snippet="Apply now",
@@ -34,6 +35,7 @@ class TestRawEvent:
 
     def test_valid_full(self) -> None:
         event = RawEvent(
+            fingerprint="abc123",
             url="https://example.com/event",
             title="Open Call",
             snippet="Apply now",
@@ -48,6 +50,7 @@ class TestRawEvent:
     def test_invalid_url(self) -> None:
         with pytest.raises(ValidationError):
             RawEvent(
+                fingerprint="abc123",
                 url="not-a-url",
                 title="Open Call",
                 snippet="Apply now",
@@ -58,6 +61,7 @@ class TestRawEvent:
     def test_missing_required_field(self) -> None:
         with pytest.raises(ValidationError):
             RawEvent(
+                fingerprint="abc123",
                 url="https://example.com/event",
                 title="Open Call",
                 # missing snippet, source, language
@@ -72,6 +76,7 @@ class TestRawEvent:
 class TestCleanEvent:
     def test_valid(self) -> None:
         event = CleanEvent(
+            fingerprint="abc123",
             title="Art Market",
             description="Annual art market in Amsterdam",
             location_text="Amsterdam, Netherlands",
@@ -85,6 +90,7 @@ class TestCleanEvent:
 
     def test_with_dates_and_geo(self) -> None:
         event = CleanEvent(
+            fingerprint="abc123",
             title="Art Market",
             description="Annual art market",
             date_start=datetime(2026, 6, 1, tzinfo=UTC),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -266,6 +266,7 @@ class TestProcessingStatus:
             ProcessingStatus.DONE,
             ProcessingStatus.FAILED,
             ProcessingStatus.OUTDATED,
+            ProcessingStatus.REQUIRES_MANUAL_VALIDATION,
         }
 
     def test_string_values(self) -> None:

--- a/tests/test_search_social.py
+++ b/tests/test_search_social.py
@@ -295,6 +295,7 @@ class TestMain:
         mock_queries = [_QUERY_NL]
         mock_events = [
             RawEvent(
+                fingerprint="abc123",
                 url="https://www.facebook.com/events/1",  # type: ignore[arg-type]
                 title="Test Event",
                 snippet="snippet",
@@ -334,6 +335,7 @@ class TestMain:
         queries = [_QUERY_NL, _QUERY_DE]
         batch_events = [
             RawEvent(
+                fingerprint=f"fp{i}",
                 url=f"https://www.facebook.com/events/{i}",  # type: ignore[arg-type]
                 title=f"Event {i}",
                 snippet="snippet",

--- a/tests/test_search_web.py
+++ b/tests/test_search_web.py
@@ -207,6 +207,7 @@ class TestWriteResults:
         from artlake.search.web import write_results
 
         event = RawEvent(
+            fingerprint="abc123",
             url="https://example.com/event",  # type: ignore[arg-type]
             title="Test Event",
             snippet="A snippet.",
@@ -268,6 +269,7 @@ class TestMain:
         mock_queries = [_QUERY_NL]
         mock_events = [
             RawEvent(
+                fingerprint="abc123",
                 url="https://example.com/event",  # type: ignore[arg-type]
                 title="Test",
                 snippet="snippet",
@@ -303,6 +305,7 @@ class TestMain:
         queries = [_QUERY_NL, _QUERY_DE]
         batch_events = [
             RawEvent(
+                fingerprint=f"fp{i}",
                 url=f"https://example.com/{i}",  # type: ignore[arg-type]
                 title=f"Event {i}",
                 snippet="snippet",

--- a/uv.lock
+++ b/uv.lock
@@ -124,6 +124,7 @@ dependencies = [
     { name = "databricks-mcp" },
     { name = "databricks-sdk" },
     { name = "databricks-vectorsearch" },
+    { name = "dateparser" },
     { name = "ddgs" },
     { name = "loguru" },
     { name = "mlflow" },
@@ -164,6 +165,7 @@ requires-dist = [
     { name = "databricks-mcp", specifier = "==0.4.0" },
     { name = "databricks-sdk", specifier = "==0.85.0" },
     { name = "databricks-vectorsearch", specifier = "==0.63" },
+    { name = "dateparser", specifier = "==1.2.1" },
     { name = "ddgs", specifier = "==9.11.4" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29.5,<7" },
     { name = "loguru", specifier = "==0.7.3" },
@@ -655,6 +657,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3f/d3207a05f5b6a78c66d86631e60bfba5af163738a599a5b9aa2c2737a09e/dateparser-1.2.1.tar.gz", hash = "sha256:7e4919aeb48481dbfc01ac9683c8e20bfe95bb715a38c1e9f6af889f4f30ccc3", size = 309924, upload-time = "2025-02-05T12:34:55.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/0a/981c438c4cd84147c781e4e96c1d72df03775deb1bc76c5a6ee8afa89c62/dateparser-1.2.1-py3-none-any.whl", hash = "sha256:bdcac262a467e6260030040748ad7c10d6bacd4f3b9cdb4cfd2251939174508c", size = 295658, upload-time = "2025-02-05T12:34:53.1Z" },
 ]
 
 [[package]]
@@ -2913,6 +2930,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **`clean/events.py`** — multi-language extraction funnel: rule-based date parsing → early outdated filter → rule-based field extraction → LLM fallback → `requires_manual_validation`. Two-mode entry point (`--mode list` / `--mode clean --url`) using `for_each_task` for per-URL parallelism (concurrency: 10), mirroring the scraper pattern.
- **`clean/patterns.py`** — new `artlake-generate-language-patterns` entry point: reads `keywords.yml`, calls LLM once to generate multilingual `title_keywords` and `location_keywords` per target language, writes `config/output/language_patterns.yml`. Eliminates all hardcoded language/country constants.
- **`resources/clean_events_job.yml`** — three-task job: `generate_language_patterns` → `list_urls` → `clean_events` (for_each, concurrency 10).
- **`models/event.py`** — `fingerprint` (sha2 of URL) added to `RawEvent` and `CleanEvent` — all four tables now carry a consistent join key for BI.
- **Docs** — ARCHITECTURE.md, BACKLOG.md, DECISIONS.md updated; ADR-024 added for language pattern generation.
- **Tests** — integration tests deselected by default (`-m 'not integration'`) in `addopts`.

## Test plan

- [x] 199 unit tests passing, coverage ≥ 80%
- [x] Pre-commit hooks clean (ruff, mypy, yaml)
- [x] Functional test on Databricks: `generate_language_patterns` → `list_urls` (15 pages) → `clean_events` for_each — all tasks succeeded end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)