### PR TITLE
feat(translate): add silver layer translation pipeline (#22, #38)

### DIFF
--- a/config/input/category_keywords.yml
+++ b/config/input/category_keywords.yml
@@ -7,7 +7,7 @@
 # Languages: EN, NL, DE, FR (matching the search query languages).
 category_keywords:
   open_call:
-    en:
+    EN:
       - open call
       - call for artists
       - call for submissions
@@ -16,25 +16,25 @@ category_keywords:
       - submission deadline
       - applications open
       - deadline to apply
-    nl:
+    NL:
       - open oproep
       - oproep voor kunstenaars
       - inschrijvingsdeadline
       - deadline inschrijving
       - aanmelden voor
-    de:
+    DE:
       - offener aufruf
       - bewerbungsschluss
       - einreichungsfrist
       - jetzt bewerben
-    fr:
+    FR:
       - appel à candidatures
       - appel ouvert
       - appel à artistes
       - date limite de candidature
 
   exhibition:
-    en:
+    EN:
       - exhibition
       - vernissage
       - opening reception
@@ -43,67 +43,67 @@ category_keywords:
       - solo show
       - gallery opening
       - on view until
-    nl:
+    NL:
       - tentoonstelling
       - expositie
       - vernissage
       - galerie-opening
-    de:
+    DE:
       - ausstellung
       - vernissage
       - galerie-eröffnung
       - kunstausstellung
-    fr:
+    FR:
       - exposition
       - vernissage
       - inauguration de
 
   workshop:
-    en:
+    EN:
       - workshop
       - masterclass
       - art class
       - art residency
       - artist residency
       - art course
-    nl:
+    NL:
       - workshop
       - masterclass
       - kunstles
       - residentie
-    de:
+    DE:
       - workshop
       - masterclass
       - kunstkurs
       - künstlerresidenz
-    fr:
+    FR:
       - atelier
       - masterclass
       - cours d'art
       - résidence artistique
 
   market:
-    en:
+    EN:
       - art market
       - art fair
       - craft fair
       - craft market
       - artisan market
-    nl:
+    NL:
       - kunstmarkt
       - kunstbeurs
       - ambachtsmarkt
-    de:
+    DE:
       - kunstmarkt
       - kunstmesse
       - kunstbörse
-    fr:
+    FR:
       - marché d'art
       - marché artisanal
       - foire d'art
 
   non_art:
-    en:
+    EN:
       - football match
       - soccer game
       - basketball game
@@ -112,15 +112,15 @@ category_keywords:
       - insurance quote
       - cryptocurrency
       - forex trading
-    nl:
+    NL:
       - voetbalwedstrijd
       - kookrecept
       - hypotheekadvies
-    de:
+    DE:
       - fußballspiel
       - kochrezept
       - versicherungsangebot
-    fr:
+    FR:
       - match de football
       - recette de cuisine
       - devis assurance

--- a/config/input/keywords.yml
+++ b/config/input/keywords.yml
@@ -1,7 +1,9 @@
+target_language: EN
+
 keywords:
   - open call artists
 
 countries:
   - code: NL
     name: Netherlands
-    languages: [nl]
+    languages: [NL]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ artlake-categorise-rules = "artlake.categorise.rules:main"
 artlake-generate-category-examples = "artlake.categorise.examples:main"
 artlake-categorise-llm = "artlake.categorise.llm:main"
 artlake-process-artifacts = "artlake.process_artifacts.extract:main"
+artlake-translate = "artlake.translate.content:main"
 
 [project.optional-dependencies]
 dev = ["databricks-connect>=17.0, <18",

--- a/resources/ingest_events_job.yml
+++ b/resources/ingest_events_job.yml
@@ -331,3 +331,55 @@ resources:
                   - "artlake.bronze.processed_artifacts"
                   - "--env"
                   - "${bundle.target}"
+
+        - task_key: list_events_to_translate
+          depends_on:
+            - task_key: process_artifacts
+          environment_key: default
+          python_wheel_task:
+            entry_point: artlake-translate
+            package_name: artlake
+            parameters:
+              - "--mode"
+              - "list"
+              - "--keywords"
+              - "${var.config_root}/config/input/keywords.yml"
+              - "--raw-events-table"
+              - "artlake.bronze.categorised_events"
+              - "--silver-events-table"
+              - "artlake.silver.events"
+              - "--env"
+              - "${bundle.target}"
+
+        - task_key: translate_events
+          depends_on:
+            - task_key: list_events_to_translate
+          for_each_task:
+            inputs: "{{tasks.list_events_to_translate.values.fingerprints}}"
+            concurrency: 5
+            task:
+              task_key: translate_event_iteration
+              max_retries: 1
+              environment_key: default
+              python_wheel_task:
+                entry_point: artlake-translate
+                package_name: artlake
+                parameters:
+                  - "--mode"
+                  - "translate"
+                  - "--fingerprint"
+                  - "{{input}}"
+                  - "--keywords"
+                  - "${var.config_root}/config/input/keywords.yml"
+                  - "--raw-events-table"
+                  - "artlake.bronze.raw_events"
+                  - "--processed-artifacts-table"
+                  - "artlake.bronze.processed_artifacts"
+                  - "--silver-events-table"
+                  - "artlake.silver.events"
+                  - "--silver-artifacts-table"
+                  - "artlake.silver.processed_artifacts"
+                  - "--model"
+                  - "databricks-meta-llama-3-3-70b-instruct"
+                  - "--env"
+                  - "${bundle.target}"

--- a/resources/translate_job.yml
+++ b/resources/translate_job.yml
@@ -1,0 +1,64 @@
+resources:
+  jobs:
+    translate_job:
+      name: translate-events
+      tags:
+        project_name: "artlake"
+
+      environments:
+        - environment_key: default
+          spec:
+            environment_version: "4"
+            dependencies:
+              - ../dist/*.whl
+
+      tasks:
+        - task_key: list_events_to_translate
+          environment_key: default
+          python_wheel_task:
+            entry_point: artlake-translate
+            package_name: artlake
+            parameters:
+              - "--mode"
+              - "list"
+              - "--keywords"
+              - "${var.config_root}/config/input/keywords.yml"
+              - "--raw-events-table"
+              - "artlake.bronze.categorised_events"
+              - "--silver-events-table"
+              - "artlake.silver.events"
+              - "--env"
+              - "${bundle.target}"
+
+        - task_key: translate_events
+          depends_on:
+            - task_key: list_events_to_translate
+          for_each_task:
+            inputs: "{{tasks.list_events_to_translate.values.fingerprints}}"
+            concurrency: 5
+            task:
+              task_key: translate_event_iteration
+              max_retries: 1
+              environment_key: default
+              python_wheel_task:
+                entry_point: artlake-translate
+                package_name: artlake
+                parameters:
+                  - "--mode"
+                  - "translate"
+                  - "--fingerprint"
+                  - "{{input}}"
+                  - "--keywords"
+                  - "${var.config_root}/config/input/keywords.yml"
+                  - "--raw-events-table"
+                  - "artlake.bronze.categorised_events"
+                  - "--processed-artifacts-table"
+                  - "artlake.bronze.processed_artifacts"
+                  - "--silver-events-table"
+                  - "artlake.silver.events"
+                  - "--silver-artifacts-table"
+                  - "artlake.silver.processed_artifacts"
+                  - "--model"
+                  - "databricks-meta-llama-3-3-70b-instruct"
+                  - "--env"
+                  - "${bundle.target}"

--- a/src/artlake/categorise/examples.py
+++ b/src/artlake/categorise/examples.py
@@ -214,7 +214,7 @@ def generate_examples(
         lang_kws = category_keywords.get(category, {})
         for language in _LANGUAGES:
             # Fall back to English keywords if language-specific ones are absent
-            keywords = lang_kws.get(language, lang_kws.get("en", []))
+            keywords = lang_kws.get(language, lang_kws.get("EN", []))
             logger.info("  language: {}", language)
             result = _call_llm(
                 client, model, category, language, keywords, n=n_per_language

--- a/src/artlake/models/config.py
+++ b/src/artlake/models/config.py
@@ -10,6 +10,6 @@ class ArtLakeConfig(BaseModel):
 
     target_countries: list[str]
     languages: list[str]
-    target_language: str = "en"
+    target_language: str = "EN"
     categories: list[str]
     scrape_schedule: str

--- a/src/artlake/models/event.py
+++ b/src/artlake/models/event.py
@@ -121,6 +121,75 @@ class ProcessedArtifact(BaseModel):
     processed_at: datetime = Field(default_factory=_now)
 
 
+class SilverEvent(BaseModel):
+    """Translated event written to silver.events."""
+
+    model_config = ConfigDict(strict=True)
+
+    fingerprint: str
+    url: HttpUrl
+    source: str
+    category: str
+
+    # Original text (source language)
+    title_original: str
+    description_original: str
+    location_text_original: str
+
+    # Translated text (target language)
+    title: str
+    description: str
+    location_text: str
+
+    # Date & geo
+    date_start: datetime | None = None
+    date_end: datetime | None = None
+    lat: float | None = None
+    lng: float | None = None
+    country: str | None = None
+    query_country: str | None = None
+    domain_country: str | None = None
+
+    # Language
+    language: str
+    target_language: str
+
+    # Artifact metadata
+    artifact_urls: list[str] = []
+    artifact_paths: list[str] = []
+
+    # Timestamps & status
+    ingested_at: datetime
+    translated_at: datetime = Field(default_factory=_now)
+    processing_status: ProcessingStatus = ProcessingStatus.DONE
+
+
+class SilverArtifact(BaseModel):
+    """Translated artifact written to silver.processed_artifacts."""
+
+    model_config = ConfigDict(strict=True)
+
+    id: str
+    event_id: str
+    artifact_type: str
+    file_path: str
+
+    # Original text (source language)
+    extracted_text_original: str | None = None
+
+    # Translated text (target language)
+    extracted_text: str | None = None
+    deadline: str | None = None
+    requirements: str | None = None
+    location: str | None = None
+    fees: str | None = None
+
+    target_language: str
+    processing_status: ProcessingStatus = ProcessingStatus.DONE
+    processed_at: datetime
+    translated_at: datetime = Field(default_factory=_now)
+
+
 class SeenUrl(BaseModel):
     """Dedup tracker written to staging.seen_urls."""
 

--- a/src/artlake/search/generate.py
+++ b/src/artlake/search/generate.py
@@ -37,7 +37,7 @@ Generate a query for each of these:
 
 Respond with ONLY a JSON array, no other text:
 [
-  {{"country_code": "XX", "language": "xx", "query": "translated query"}}
+  {{"country_code": "XX", "language": "XX", "query": "translated query"}}
 ]"""
 
 

--- a/src/artlake/translate/__init__.py
+++ b/src/artlake/translate/__init__.py
@@ -1,0 +1,1 @@
+"""Content translation — event fields and artifact text to the target language."""

--- a/src/artlake/translate/content.py
+++ b/src/artlake/translate/content.py
@@ -1,0 +1,758 @@
+"""Content translator — event fields and artifact text to the target language.
+
+Entry point: artlake-translate
+
+Reads art-categorised, geocoded CleanEvent records from
+artlake.bronze.raw_events (category NOT IN ('non_art') AND
+processing_status = 'done'), joins their ProcessedArtifact rows from
+artlake.bronze.processed_artifacts, translates all text in one LLM call
+per event, and writes:
+
+  artlake.silver.events              — translated event fields
+  artlake.silver.processed_artifacts — translated artifact content
+
+Events already in the target language are promoted to silver without an
+LLM call (original == translated).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import backoff
+import yaml
+from loguru import logger
+from openai import OpenAI
+
+from artlake.models.event import ProcessingStatus, SilverArtifact, SilverEvent
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+    from pyspark.sql.types import StructType
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_MODEL = "databricks-meta-llama-3-3-70b-instruct"
+_RAW_EVENTS_TABLE_DEFAULT = "artlake.bronze.categorised_events"
+_PROCESSED_ARTIFACTS_TABLE_DEFAULT = "artlake.bronze.processed_artifacts"
+_SILVER_EVENTS_TABLE_DEFAULT = "artlake.silver.events"
+_SILVER_ARTIFACTS_TABLE_DEFAULT = "artlake.silver.processed_artifacts"
+
+_EVENT_FIELDS = ["title", "description", "location_text"]
+_ARTIFACT_FIELDS = ["extracted_text", "deadline", "requirements", "location", "fees"]
+
+# ---------------------------------------------------------------------------
+# Pure helpers — fully testable without Spark or a live LLM
+# ---------------------------------------------------------------------------
+
+
+def build_system_prompt(target_language: str) -> str:
+    """Build the LLM system prompt for translation."""
+    return (
+        f"You are a professional translator.\n"
+        f"Translate all non-null string values in the following JSON to"
+        f" {target_language}.\n"
+        f"Return ONLY a valid JSON object with exactly the same structure and keys.\n"
+        f"Preserve null values as null. Do not add, remove, or rename any keys.\n"
+        f"Do not add explanations or markdown fences."
+    )
+
+
+def build_translation_payload(
+    event_title: str,
+    event_description: str,
+    event_location_text: str,
+    artifacts: list[dict[str, str | None]],
+) -> dict[str, Any]:
+    """Build the JSON payload sent to the LLM for translation.
+
+    Args:
+        event_title: Event title in source language.
+        event_description: Event description in source language.
+        event_location_text: Location text in source language.
+        artifacts: List of artifact dicts, each with keys id,
+            extracted_text, deadline, requirements, location, fees.
+
+    Returns:
+        Dict with ``event`` and ``artifacts`` keys.
+    """
+    return {
+        "event": {
+            "title": event_title,
+            "description": event_description,
+            "location_text": event_location_text,
+        },
+        "artifacts": [
+            {
+                "id": a["id"],
+                "extracted_text": a.get("extracted_text"),
+                "deadline": a.get("deadline"),
+                "requirements": a.get("requirements"),
+                "location": a.get("location"),
+                "fees": a.get("fees"),
+            }
+            for a in artifacts
+        ],
+    }
+
+
+def _extract_str(data: dict[str, Any], key: str) -> str | None:
+    val = data.get(key)
+    return val if isinstance(val, str) else None
+
+
+def _parse_ts(value: datetime | str) -> datetime:
+    """Parse a Delta-stored timestamp string or pass through a datetime."""
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(str(value))
+
+
+def parse_translation_response(
+    content: str,
+    artifact_ids: list[str],
+) -> dict[str, Any]:
+    """Parse the LLM translation response.
+
+    Strips optional markdown fences then parses JSON.  Returns a dict::
+
+        {
+            "event": {"title": ..., "description": ..., "location_text": ...},
+            "artifacts": [
+                {"id": ..., "extracted_text": ..., "deadline": ...,
+                 "requirements": ..., "location": ..., "fees": ...},
+                ...
+            ],
+        }
+
+    Missing or non-string values default to None.  Artifacts are matched by
+    ``id``; any artifact ID absent from the response gets all-None fields.
+
+    Args:
+        content: Raw LLM response, optionally wrapped in ```json fences.
+        artifact_ids: IDs of artifacts included in the original payload,
+            used to fill in defaults for any missing response entries.
+
+    Returns:
+        Parsed translation dict.
+    """
+    cleaned = re.sub(r"```(?:json)?\s*", "", content).strip().rstrip("`").strip()
+    data: dict[str, Any] = json.loads(cleaned)
+
+    raw_event: dict[str, Any] = data.get("event") or {}
+    event_out = {f: _extract_str(raw_event, f) for f in _EVENT_FIELDS}
+
+    raw_artifacts: list[dict[str, Any]] = data.get("artifacts") or []
+    by_id: dict[str, dict[str, Any]] = {
+        str(a.get("id", "")): a for a in raw_artifacts if isinstance(a, dict)
+    }
+    artifacts_out = []
+    for art_id in artifact_ids:
+        raw = by_id.get(art_id, {})
+        artifacts_out.append(
+            {
+                "id": art_id,
+                **{f: _extract_str(raw, f) for f in _ARTIFACT_FIELDS},
+            }
+        )
+
+    return {"event": event_out, "artifacts": artifacts_out}
+
+
+def make_silver_event(
+    fingerprint: str,
+    url: str,
+    source: str,
+    category: str,
+    title_original: str,
+    description_original: str,
+    location_text_original: str,
+    date_start: datetime | str | None,
+    date_end: datetime | str | None,
+    lat: float | None,
+    lng: float | None,
+    country: str | None,
+    query_country: str | None,
+    domain_country: str | None,
+    language: str,
+    target_language: str,
+    artifact_urls: list[str],
+    artifact_paths: list[str],
+    ingested_at: datetime | str,
+    translated_title: str | None,
+    translated_description: str | None,
+    translated_location_text: str | None,
+) -> SilverEvent:
+    """Construct a SilverEvent, falling back to original text on null translation.
+
+    Args:
+        fingerprint: Event fingerprint (SHA256 of URL).
+        url: Canonical event URL.
+        source: Search result source domain.
+        category: Art category assigned by the categorisation step.
+        title_original: Event title in source language.
+        description_original: Event description in source language.
+        location_text_original: Location text in source language.
+        date_start: Parsed event start date (datetime or None).
+        date_end: Parsed event end date (datetime or None).
+        lat: Latitude from geocoding.
+        lng: Longitude from geocoding.
+        country: ISO country code.
+        query_country: Country used in the original search query.
+        domain_country: Country inferred from the event URL domain.
+        language: Source language code (BCP-47, e.g. ``"nl"``).
+        target_language: Translation target language code.
+        artifact_urls: URLs of attached artifacts.
+        artifact_paths: UC Volume paths of downloaded artifacts.
+        ingested_at: Timestamp from the original CleanEvent record.
+        translated_title: LLM-translated title, or None (falls back to original).
+        translated_description: LLM-translated description, or None.
+        translated_location_text: LLM-translated location text, or None.
+
+    Returns:
+        A :class:`SilverEvent` ready to be written to Delta.
+    """
+    return SilverEvent(
+        fingerprint=fingerprint,
+        url=url,  # type: ignore[arg-type]
+        source=source,
+        category=category,
+        title_original=title_original,
+        description_original=description_original,
+        location_text_original=location_text_original,
+        title=translated_title or title_original,
+        description=translated_description or description_original,
+        location_text=translated_location_text or location_text_original,
+        date_start=_parse_ts(date_start) if date_start is not None else None,
+        date_end=_parse_ts(date_end) if date_end is not None else None,
+        lat=lat,
+        lng=lng,
+        country=country,
+        query_country=query_country,
+        domain_country=domain_country,
+        language=language,
+        target_language=target_language,
+        artifact_urls=artifact_urls,
+        artifact_paths=artifact_paths,
+        ingested_at=_parse_ts(ingested_at),
+    )
+
+
+def make_silver_artifact(
+    artifact_id: str,
+    event_id: str,
+    artifact_type: str,
+    file_path: str,
+    extracted_text_original: str | None,
+    processed_at: datetime | str,
+    target_language: str,
+    translated_extracted_text: str | None,
+    translated_deadline: str | None,
+    translated_requirements: str | None,
+    translated_location: str | None,
+    translated_fees: str | None,
+) -> SilverArtifact:
+    """Construct a SilverArtifact, falling back to originals on null translation.
+
+    Args:
+        artifact_id: Artifact ID (SHA256 of artifact URL).
+        event_id: Parent event fingerprint.
+        artifact_type: ``'pdf'`` or ``'image'``.
+        file_path: UC Volume path of the raw artifact file.
+        extracted_text_original: Full extracted text in source language.
+        processed_at: Timestamp from the original ProcessedArtifact record.
+        target_language: Translation target language code.
+        translated_extracted_text: Translated extracted text, or None.
+        translated_deadline: Translated deadline, or None.
+        translated_requirements: Translated requirements, or None.
+        translated_location: Translated location, or None.
+        translated_fees: Translated fees, or None.
+
+    Returns:
+        A :class:`SilverArtifact` ready to be written to Delta.
+    """
+    return SilverArtifact(
+        id=artifact_id,
+        event_id=event_id,
+        artifact_type=artifact_type,
+        file_path=file_path,
+        extracted_text_original=extracted_text_original,
+        extracted_text=translated_extracted_text or extracted_text_original,
+        deadline=translated_deadline,
+        requirements=translated_requirements,
+        location=translated_location,
+        fees=translated_fees,
+        target_language=target_language,
+        processed_at=_parse_ts(processed_at),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+def load_target_language(keywords_path: str) -> str:
+    """Read target_language from the keywords YAML config.
+
+    Args:
+        keywords_path: Path to ``config/input/keywords.yml``.
+
+    Returns:
+        Target language code, defaults to ``"en"`` if not set.
+    """
+    with open(keywords_path) as fh:
+        cfg = yaml.safe_load(fh) or {}
+    return str(cfg.get("target_language", "EN"))
+
+
+# ---------------------------------------------------------------------------
+# LLM interaction
+# ---------------------------------------------------------------------------
+
+
+def _create_default_client() -> OpenAI:  # pragma: no cover
+    """Create an OpenAI client using Databricks workspace auth."""
+    from databricks.sdk import WorkspaceClient
+
+    w = WorkspaceClient()
+    host = w.config.host or ""
+    token = w.tokens.create(lifetime_seconds=1200).token_value
+    return OpenAI(
+        api_key=token,
+        base_url=f"{host.rstrip('/')}/serving-endpoints",
+    )
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+def _translate_text(
+    payload: dict[str, Any],
+    client: OpenAI,
+    model: str,
+    target_language: str,
+) -> dict[str, Any]:
+    """Send the translation payload to the LLM and return parsed translations.
+
+    Args:
+        payload: Dict built by :func:`build_translation_payload`.
+        client: OpenAI client pointed at Databricks serving endpoints.
+        model: Model name.
+        target_language: Target language for translation.
+
+    Returns:
+        Parsed translation dict from :func:`parse_translation_response`.
+    """
+    artifact_ids = [a["id"] for a in payload.get("artifacts", [])]
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": build_system_prompt(target_language)},
+            {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
+        ],
+        temperature=0.0,
+        max_tokens=4096,
+    )
+    raw = response.choices[0].message.content or ""
+    return parse_translation_response(raw, artifact_ids)
+
+
+# ---------------------------------------------------------------------------
+# Spark integration (pragma: no cover — tested via integration marker)
+# ---------------------------------------------------------------------------
+
+
+def _silver_event_schema() -> StructType:  # pragma: no cover
+    from pyspark.sql.types import (
+        ArrayType,
+        DoubleType,
+        StringType,
+        StructField,
+        StructType,
+        TimestampType,
+    )
+
+    return StructType(
+        [
+            StructField("fingerprint", StringType(), False),
+            StructField("url", StringType(), False),
+            StructField("source", StringType(), False),
+            StructField("category", StringType(), False),
+            StructField("title_original", StringType(), False),
+            StructField("description_original", StringType(), False),
+            StructField("location_text_original", StringType(), False),
+            StructField("title", StringType(), False),
+            StructField("description", StringType(), False),
+            StructField("location_text", StringType(), False),
+            StructField("date_start", TimestampType(), True),
+            StructField("date_end", TimestampType(), True),
+            StructField("lat", DoubleType(), True),
+            StructField("lng", DoubleType(), True),
+            StructField("country", StringType(), True),
+            StructField("query_country", StringType(), True),
+            StructField("domain_country", StringType(), True),
+            StructField("language", StringType(), False),
+            StructField("target_language", StringType(), False),
+            StructField("artifact_urls", ArrayType(StringType()), False),
+            StructField("artifact_paths", ArrayType(StringType()), False),
+            StructField("ingested_at", TimestampType(), False),
+            StructField("translated_at", TimestampType(), False),
+            StructField("processing_status", StringType(), False),
+        ]
+    )
+
+
+def _silver_artifact_schema() -> StructType:  # pragma: no cover
+    from pyspark.sql.types import StringType, StructField, StructType, TimestampType
+
+    return StructType(
+        [
+            StructField("id", StringType(), False),
+            StructField("event_id", StringType(), False),
+            StructField("artifact_type", StringType(), False),
+            StructField("file_path", StringType(), False),
+            StructField("extracted_text_original", StringType(), True),
+            StructField("extracted_text", StringType(), True),
+            StructField("deadline", StringType(), True),
+            StructField("requirements", StringType(), True),
+            StructField("location", StringType(), True),
+            StructField("fees", StringType(), True),
+            StructField("target_language", StringType(), False),
+            StructField("processing_status", StringType(), False),
+            StructField("processed_at", TimestampType(), False),
+            StructField("translated_at", TimestampType(), False),
+        ]
+    )
+
+
+def _write_silver_event(  # pragma: no cover
+    spark: SparkSession,
+    event: SilverEvent,
+    table: str,
+) -> None:
+    schema = _silver_event_schema()
+    row = event.model_dump(mode="python")
+    row["url"] = str(row["url"])
+
+    df = spark.createDataFrame([row], schema=schema)
+
+    parts = table.split(".")
+    if len(parts) == 3:
+        catalog, db, _ = parts
+        spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{db}")
+
+    (
+        df.write.format("delta")
+        .mode("append")
+        .option("mergeSchema", "true")
+        .saveAsTable(table)
+    )
+
+
+def _write_silver_artifact(  # pragma: no cover
+    spark: SparkSession,
+    artifact: SilverArtifact,
+    table: str,
+) -> None:
+    schema = _silver_artifact_schema()
+    row = artifact.model_dump(mode="python")
+
+    df = spark.createDataFrame([row], schema=schema)
+
+    parts = table.split(".")
+    if len(parts) == 3:
+        catalog, db, _ = parts
+        spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{db}")
+
+    (
+        df.write.format("delta")
+        .mode("append")
+        .option("mergeSchema", "true")
+        .saveAsTable(table)
+    )
+
+
+def run_list(  # pragma: no cover
+    raw_events_table: str,
+    silver_events_table: str,
+    limit: int = 0,
+) -> list[str]:
+    """Emit fingerprints of events not yet translated as a Databricks task value.
+
+    Reads ``raw_events`` where ``category NOT IN ('non_art') AND
+    processing_status = 'done'`` and anti-joins with ``silver_events``
+    (already translated) so events are not translated twice.
+
+    Returns the list of fingerprints to translate.
+    """
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    spark = SparkSession.builder.getOrCreate()
+
+    pending_df = (
+        spark.table(raw_events_table)
+        .filter(
+            (F.col("category") != "non_art")
+            & (F.col("processing_status") == ProcessingStatus.DONE.value)
+        )
+        .select("fingerprint")
+        .distinct()
+    )
+
+    if spark.catalog.tableExists(silver_events_table):
+        done_df = (
+            spark.table(silver_events_table)
+            .filter(F.col("processing_status") == ProcessingStatus.DONE.value)
+            .select("fingerprint")
+        )
+        pending_df = pending_df.join(done_df, on="fingerprint", how="left_anti")
+    else:
+        logger.info("silver.events table does not exist yet — all events are new")
+
+    if limit > 0:
+        pending_df = pending_df.limit(limit)
+
+    fingerprints: list[str] = [row["fingerprint"] for row in pending_df.collect()]
+    logger.info("Event fingerprints to translate: {}", len(fingerprints))
+
+    try:
+        from databricks.sdk.runtime import dbutils
+
+        dbutils.jobs.taskValues.set(key="fingerprints", value=fingerprints)
+        logger.info("Task value 'fingerprints' set with {} entries", len(fingerprints))
+    except ImportError:
+        logger.warning("dbutils not available — skipping task value set")
+
+    return fingerprints
+
+
+def run_translate(  # pragma: no cover
+    fingerprint: str,
+    raw_events_table: str,
+    processed_artifacts_table: str,
+    silver_events_table: str,
+    silver_artifacts_table: str,
+    target_language: str,
+    model: str = _DEFAULT_MODEL,
+) -> None:
+    """Translate one event and its artifacts, writing to the silver tables.
+
+    Reads the CleanEvent record from ``raw_events`` and all ProcessedArtifact
+    rows for that event from ``processed_artifacts``.  If the event language
+    matches the target language, fields are promoted to silver unchanged.
+    Otherwise a single LLM call translates all text fields at once.
+    """
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    spark = SparkSession.builder.getOrCreate()
+
+    # -- Read event -----------------------------------------------------------
+    event_rows = (
+        spark.table(raw_events_table)
+        .filter(F.col("fingerprint") == fingerprint)
+        .limit(1)
+        .collect()
+    )
+    if not event_rows:
+        logger.warning("No raw_event found for fingerprint: {}", fingerprint)
+        return
+    ev = event_rows[0]
+
+    # -- Read artifacts -------------------------------------------------------
+    artifact_rows: list[Any] = []
+    if spark.catalog.tableExists(processed_artifacts_table):
+        artifact_rows = (
+            spark.table(processed_artifacts_table)
+            .filter(
+                (F.col("event_id") == fingerprint)
+                & (F.col("processing_status") == ProcessingStatus.DONE.value)
+            )
+            .collect()
+        )
+
+    artifacts_payload = [
+        {
+            "id": a["id"],
+            "extracted_text": a["extracted_text"],
+            "deadline": a["deadline"],
+            "requirements": a["requirements"],
+            "location": a["location"],
+            "fees": a["fees"],
+        }
+        for a in artifact_rows
+    ]
+    # -- Translate or copy ----------------------------------------------------
+    source_language: str = ev["language"] or ""
+    translation: dict[str, Any] = {"event": {}, "artifacts": []}
+
+    if source_language == target_language:
+        logger.info(
+            "Event {} is already in {} — promoting to silver without translation",
+            fingerprint,
+            target_language,
+        )
+    else:
+        try:
+            client = _create_default_client()
+            payload = build_translation_payload(
+                event_title=ev["title"],
+                event_description=ev["description"],
+                event_location_text=ev["location_text"],
+                artifacts=artifacts_payload,
+            )
+            translation = _translate_text(payload, client, model, target_language)
+            logger.info("Translation complete for fingerprint: {}", fingerprint)
+        except Exception as exc:
+            logger.error(
+                "Translation failed for fingerprint {} — "
+                "promoting with original text: {}",
+                fingerprint,
+                exc,
+            )
+
+    event_translation: dict[str, str | None] = translation.get("event") or {}
+    artifact_translations: dict[str, dict[str, str | None]] = {
+        a["id"]: a for a in (translation.get("artifacts") or [])
+    }
+
+    # -- Write silver.events --------------------------------------------------
+    silver_event = make_silver_event(
+        fingerprint=fingerprint,
+        url=str(ev["url"]),
+        source=ev["source"],
+        category=ev["category"],
+        title_original=ev["title"],
+        description_original=ev["description"],
+        location_text_original=ev["location_text"],
+        date_start=ev["date_start"],
+        date_end=ev["date_end"],
+        lat=ev["lat"],
+        lng=ev["lng"],
+        country=ev["country"],
+        query_country=ev["query_country"],
+        domain_country=ev["domain_country"],
+        language=source_language,
+        target_language=target_language,
+        artifact_urls=list(ev["artifact_urls"] or []),
+        artifact_paths=list(ev["artifact_paths"] or []),
+        ingested_at=ev["ingested_at"],
+        translated_title=event_translation.get("title"),
+        translated_description=event_translation.get("description"),
+        translated_location_text=event_translation.get("location_text"),
+    )
+    _write_silver_event(spark, silver_event, silver_events_table)
+    logger.info("Wrote SilverEvent for fingerprint: {}", fingerprint)
+
+    # -- Write silver.processed_artifacts -------------------------------------
+    for art in artifact_rows:
+        art_translation = artifact_translations.get(art["id"], {})
+        silver_artifact = make_silver_artifact(
+            artifact_id=art["id"],
+            event_id=art["event_id"],
+            artifact_type=art["artifact_type"],
+            file_path=art["file_path"],
+            extracted_text_original=art["extracted_text"],
+            processed_at=art["processed_at"],
+            target_language=target_language,
+            translated_extracted_text=art_translation.get("extracted_text"),
+            translated_deadline=art_translation.get("deadline"),
+            translated_requirements=art_translation.get("requirements"),
+            translated_location=art_translation.get("location"),
+            translated_fees=art_translation.get("fees"),
+        )
+        _write_silver_artifact(spark, silver_artifact, silver_artifacts_table)
+        logger.info(
+            "Wrote SilverArtifact id: {} for fingerprint: {}", art["id"], fingerprint
+        )
+
+
+def main() -> None:  # pragma: no cover
+    """Entry point for artlake-translate wheel task.
+
+    Two modes:
+      list      — Emit fingerprints of untranslated events as a Databricks
+                  task value for a downstream for_each_task.
+      translate — Translate one event and its artifacts (for_each inner task).
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description="ArtLake content translator")
+    parser.add_argument(
+        "--mode",
+        choices=["list", "translate"],
+        required=True,
+        help="'list' emits fingerprints as a task value; 'translate' processes one event",
+    )
+    parser.add_argument(
+        "--fingerprint",
+        help="Event fingerprint to translate (required for --mode translate)",
+    )
+    parser.add_argument(
+        "--keywords",
+        required=True,
+        help="Path to config/input/keywords.yml (provides target_language)",
+    )
+    parser.add_argument(
+        "--raw-events-table",
+        default=_RAW_EVENTS_TABLE_DEFAULT,
+        help="Fully-qualified raw_events Delta table",
+    )
+    parser.add_argument(
+        "--processed-artifacts-table",
+        default=_PROCESSED_ARTIFACTS_TABLE_DEFAULT,
+        help="Fully-qualified processed_artifacts Delta table",
+    )
+    parser.add_argument(
+        "--silver-events-table",
+        default=_SILVER_EVENTS_TABLE_DEFAULT,
+        help="Fully-qualified silver.events Delta table",
+    )
+    parser.add_argument(
+        "--silver-artifacts-table",
+        default=_SILVER_ARTIFACTS_TABLE_DEFAULT,
+        help="Fully-qualified silver.processed_artifacts Delta table",
+    )
+    parser.add_argument(
+        "--model",
+        default=_DEFAULT_MODEL,
+        help="Databricks Foundation Model endpoint name",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Max fingerprints to emit in list mode (0 = no limit)",
+    )
+    parser.add_argument(
+        "--env",
+        default="dev",
+        help="Deployment environment (dev/tst/acc/prd)",
+    )
+    args = parser.parse_args()
+
+    target_language = load_target_language(args.keywords)
+
+    if args.mode == "list":
+        run_list(
+            raw_events_table=args.raw_events_table,
+            silver_events_table=args.silver_events_table,
+            limit=args.limit,
+        )
+    else:
+        if not args.fingerprint:
+            parser.error("--fingerprint is required for --mode translate")
+        run_translate(
+            fingerprint=args.fingerprint,
+            raw_events_table=args.raw_events_table,
+            processed_artifacts_table=args.processed_artifacts_table,
+            silver_events_table=args.silver_events_table,
+            silver_artifacts_table=args.silver_artifacts_table,
+            target_language=target_language,
+            model=args.model,
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -260,21 +260,21 @@ class TestArtLakeConfig:
     def test_valid(self) -> None:
         config = ArtLakeConfig(
             target_countries=["NL", "BE", "DE", "FR"],
-            languages=["en", "nl", "de", "fr"],
+            languages=["EN", "NL", "DE", "FR"],
             categories=["open_call", "market", "exhibition", "workshop"],
             scrape_schedule="0 6 * * *",
         )
-        assert config.target_language == "en"
+        assert config.target_language == "EN"
 
     def test_custom_target_language(self) -> None:
         config = ArtLakeConfig(
             target_countries=["NL"],
-            languages=["nl"],
-            target_language="nl",
+            languages=["NL"],
+            target_language="NL",
             categories=["open_call"],
             scrape_schedule="0 6 * * *",
         )
-        assert config.target_language == "nl"
+        assert config.target_language == "NL"
 
     def test_missing_required(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/test_translate_content.py
+++ b/tests/test_translate_content.py
@@ -1,0 +1,423 @@
+"""Tests for translate/content.py."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from artlake.translate.content import (
+    _translate_text,
+    build_system_prompt,
+    build_translation_payload,
+    load_target_language,
+    make_silver_artifact,
+    make_silver_event,
+    parse_translation_response,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 3, 31, 12, 0, 0, tzinfo=UTC)
+
+_ARTIFACT_IDS = ["art001", "art002"]
+
+_FULL_PAYLOAD: dict = {
+    "event": {
+        "title": "Tentoonstelling: Zichtbaarheid",
+        "description": "Een groepstentoonstelling over hedendaagse kunst.",
+        "location_text": "Amsterdam, Nederland",
+    },
+    "artifacts": [
+        {
+            "id": "art001",
+            "extracted_text": "Oproep voor kunstenaars. Deadline 15 april.",
+            "deadline": "15 april 2026",
+            "requirements": "Portfolio van 10 werken",
+            "location": "Rotterdam, NL",
+            "fees": "Geen kosten",
+        },
+        {
+            "id": "art002",
+            "extracted_text": None,
+            "deadline": None,
+            "requirements": None,
+            "location": None,
+            "fees": None,
+        },
+    ],
+}
+
+_FULL_TRANSLATION_RESPONSE: dict = {
+    "event": {
+        "title": "Exhibition: Visibility",
+        "description": "A group exhibition on contemporary art.",
+        "location_text": "Amsterdam, Netherlands",
+    },
+    "artifacts": [
+        {
+            "id": "art001",
+            "extracted_text": "Call for artists. Deadline 15 April.",
+            "deadline": "15 April 2026",
+            "requirements": "Portfolio of 10 works",
+            "location": "Rotterdam, NL",
+            "fees": "No costs",
+        },
+        {
+            "id": "art002",
+            "extracted_text": None,
+            "deadline": None,
+            "requirements": None,
+            "location": None,
+            "fees": None,
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSystemPrompt:
+    def test_mentions_target_language(self) -> None:
+        prompt = build_system_prompt("English")
+        assert "English" in prompt
+
+    def test_instructs_json_only_response(self) -> None:
+        prompt = build_system_prompt("en")
+        assert "JSON" in prompt
+
+    def test_preserves_null_instruction(self) -> None:
+        prompt = build_system_prompt("en")
+        assert "null" in prompt
+
+    def test_no_add_remove_keys_instruction(self) -> None:
+        prompt = build_system_prompt("en")
+        assert "keys" in prompt
+
+
+# ---------------------------------------------------------------------------
+# build_translation_payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTranslationPayload:
+    def test_event_fields_present(self) -> None:
+        payload = build_translation_payload(
+            event_title="Title",
+            event_description="Desc",
+            event_location_text="Loc",
+            artifacts=[],
+        )
+        assert payload["event"]["title"] == "Title"
+        assert payload["event"]["description"] == "Desc"
+        assert payload["event"]["location_text"] == "Loc"
+
+    def test_artifacts_list_preserved(self) -> None:
+        artifacts = [
+            {
+                "id": "a1",
+                "extracted_text": "text",
+                "deadline": "d",
+                "requirements": "r",
+                "location": "l",
+                "fees": "f",
+            }
+        ]
+        payload = build_translation_payload("T", "D", "L", artifacts)
+        assert len(payload["artifacts"]) == 1
+        assert payload["artifacts"][0]["id"] == "a1"
+        assert payload["artifacts"][0]["extracted_text"] == "text"
+
+    def test_artifact_none_fields_preserved(self) -> None:
+        artifacts = [
+            {
+                "id": "a1",
+                "extracted_text": None,
+                "deadline": None,
+                "requirements": None,
+                "location": None,
+                "fees": None,
+            }
+        ]
+        payload = build_translation_payload("T", "D", "L", artifacts)
+        assert payload["artifacts"][0]["extracted_text"] is None
+
+    def test_empty_artifacts(self) -> None:
+        payload = build_translation_payload("T", "D", "L", [])
+        assert payload["artifacts"] == []
+
+
+# ---------------------------------------------------------------------------
+# parse_translation_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseTranslationResponse:
+    def test_happy_path_all_fields(self) -> None:
+        content = json.dumps(_FULL_TRANSLATION_RESPONSE)
+        result = parse_translation_response(content, _ARTIFACT_IDS)
+
+        assert result["event"]["title"] == "Exhibition: Visibility"
+        assert result["event"]["location_text"] == "Amsterdam, Netherlands"
+
+        art001 = next(a for a in result["artifacts"] if a["id"] == "art001")
+        assert art001["deadline"] == "15 April 2026"
+        assert art001["extracted_text"] == "Call for artists. Deadline 15 April."
+
+        art002 = next(a for a in result["artifacts"] if a["id"] == "art002")
+        assert art002["extracted_text"] is None
+        assert art002["deadline"] is None
+
+    def test_strips_markdown_fences(self) -> None:
+        content = "```json\n" + json.dumps(_FULL_TRANSLATION_RESPONSE) + "\n```"
+        result = parse_translation_response(content, _ARTIFACT_IDS)
+        assert result["event"]["title"] == "Exhibition: Visibility"
+
+    def test_missing_artifact_in_response_defaults_to_none(self) -> None:
+        response = {
+            "event": {"title": "T", "description": "D", "location_text": "L"},
+            "artifacts": [],
+        }
+        content = json.dumps(response)
+        result = parse_translation_response(content, ["art001"])
+        art = result["artifacts"][0]
+        assert art["id"] == "art001"
+        assert art["extracted_text"] is None
+        assert art["deadline"] is None
+
+    def test_non_string_event_values_become_none(self) -> None:
+        response = {
+            "event": {"title": 42, "description": ["a", "b"], "location_text": None},
+            "artifacts": [],
+        }
+        result = parse_translation_response(json.dumps(response), [])
+        assert result["event"]["title"] is None
+        assert result["event"]["description"] is None
+        assert result["event"]["location_text"] is None
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            parse_translation_response("not json", [])
+
+    def test_no_artifacts_in_payload(self) -> None:
+        response = {
+            "event": {"title": "T", "description": "D", "location_text": "L"},
+            "artifacts": [],
+        }
+        result = parse_translation_response(json.dumps(response), [])
+        assert result["artifacts"] == []
+
+
+# ---------------------------------------------------------------------------
+# make_silver_event
+# ---------------------------------------------------------------------------
+
+
+class TestMakeSilverEvent:
+    def _base_kwargs(self) -> dict:
+        return {
+            "fingerprint": "fp123",
+            "url": "https://example.com/event",
+            "source": "example.com",
+            "category": "open_call",
+            "title_original": "Tentoonstelling",
+            "description_original": "Beschrijving",
+            "location_text_original": "Amsterdam",
+            "date_start": _NOW,
+            "date_end": None,
+            "lat": 52.37,
+            "lng": 4.9,
+            "country": "NL",
+            "query_country": "NL",
+            "domain_country": "NL",
+            "language": "nl",
+            "target_language": "en",
+            "artifact_urls": ["https://example.com/call.pdf"],
+            "artifact_paths": ["/Volumes/artlake/volumes/raw_artifacts/fp123/call.pdf"],
+            "ingested_at": _NOW,
+            "translated_title": "Exhibition",
+            "translated_description": "Description",
+            "translated_location_text": "Amsterdam",
+        }
+
+    def test_translated_fields_applied(self) -> None:
+        event = make_silver_event(**self._base_kwargs())
+        assert event.title == "Exhibition"
+        assert event.description == "Description"
+
+    def test_original_fields_preserved(self) -> None:
+        event = make_silver_event(**self._base_kwargs())
+        assert event.title_original == "Tentoonstelling"
+        assert event.description_original == "Beschrijving"
+
+    def test_fallback_to_original_when_translation_null(self) -> None:
+        kwargs = self._base_kwargs()
+        kwargs["translated_title"] = None
+        kwargs["translated_description"] = None
+        kwargs["translated_location_text"] = None
+        event = make_silver_event(**kwargs)
+        assert event.title == "Tentoonstelling"
+        assert event.description == "Beschrijving"
+        assert event.location_text == "Amsterdam"
+
+    def test_language_fields_set(self) -> None:
+        event = make_silver_event(**self._base_kwargs())
+        assert event.language == "nl"
+        assert event.target_language == "en"
+
+    def test_fingerprint_and_category(self) -> None:
+        event = make_silver_event(**self._base_kwargs())
+        assert event.fingerprint == "fp123"
+        assert event.category == "open_call"
+
+    def test_geo_fields_preserved(self) -> None:
+        event = make_silver_event(**self._base_kwargs())
+        assert event.lat == pytest.approx(52.37)
+        assert event.lng == pytest.approx(4.9)
+        assert event.country == "NL"
+
+
+# ---------------------------------------------------------------------------
+# make_silver_artifact
+# ---------------------------------------------------------------------------
+
+
+class TestMakeSilverArtifact:
+    def _base_kwargs(self) -> dict:
+        return {
+            "artifact_id": "art001",
+            "event_id": "fp123",
+            "artifact_type": "pdf",
+            "file_path": "/Volumes/artlake/volumes/raw_artifacts/fp123/call.pdf",
+            "extracted_text_original": "Oproep voor kunstenaars.",
+            "processed_at": _NOW,
+            "target_language": "en",
+            "translated_extracted_text": "Call for artists.",
+            "translated_deadline": "15 April 2026",
+            "translated_requirements": "Portfolio of 10 works",
+            "translated_location": "Rotterdam, NL",
+            "translated_fees": "No costs",
+        }
+
+    def test_translated_fields_applied(self) -> None:
+        artifact = make_silver_artifact(**self._base_kwargs())
+        assert artifact.extracted_text == "Call for artists."
+        assert artifact.deadline == "15 April 2026"
+        assert artifact.fees == "No costs"
+
+    def test_original_preserved(self) -> None:
+        artifact = make_silver_artifact(**self._base_kwargs())
+        assert artifact.extracted_text_original == "Oproep voor kunstenaars."
+
+    def test_fallback_to_original_when_translation_null(self) -> None:
+        kwargs = self._base_kwargs()
+        kwargs["translated_extracted_text"] = None
+        artifact = make_silver_artifact(**kwargs)
+        assert artifact.extracted_text == "Oproep voor kunstenaars."
+
+    def test_all_none_translated_fields(self) -> None:
+        kwargs = self._base_kwargs()
+        kwargs.update(
+            translated_extracted_text=None,
+            translated_deadline=None,
+            translated_requirements=None,
+            translated_location=None,
+            translated_fees=None,
+        )
+        artifact = make_silver_artifact(**kwargs)
+        assert artifact.deadline is None
+        assert artifact.requirements is None
+        assert artifact.location is None
+        assert artifact.fees is None
+
+    def test_identity_fields(self) -> None:
+        artifact = make_silver_artifact(**self._base_kwargs())
+        assert artifact.id == "art001"
+        assert artifact.event_id == "fp123"
+        assert artifact.artifact_type == "pdf"
+        assert artifact.target_language == "en"
+
+
+# ---------------------------------------------------------------------------
+# load_target_language
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTargetLanguage:
+    def test_reads_target_language_field(self) -> None:
+        yaml_content = "target_language: fr\nkeywords:\n  - open call\n"
+        with patch("builtins.open", mock_open(read_data=yaml_content)):
+            result = load_target_language("config/input/keywords.yml")
+        assert result == "fr"
+
+    def test_defaults_to_EN_when_field_missing(self) -> None:
+        yaml_content = "keywords:\n  - open call\n"
+        with patch("builtins.open", mock_open(read_data=yaml_content)):
+            result = load_target_language("config/input/keywords.yml")
+        assert result == "EN"
+
+
+# ---------------------------------------------------------------------------
+# _translate_text (mocked LLM)
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateText:
+    def _mock_client(self, response_content: str) -> MagicMock:
+        client = MagicMock()
+        choice = MagicMock()
+        choice.message.content = response_content
+        client.chat.completions.create.return_value = MagicMock(choices=[choice])
+        return client
+
+    def test_returns_parsed_translation(self) -> None:
+        content = json.dumps(_FULL_TRANSLATION_RESPONSE)
+        client = self._mock_client(content)
+        result = _translate_text(_FULL_PAYLOAD, client, "mock-model", "en")
+        assert result["event"]["title"] == "Exhibition: Visibility"
+        art001 = next(a for a in result["artifacts"] if a["id"] == "art001")
+        assert art001["deadline"] == "15 April 2026"
+
+    def test_passes_system_prompt_and_payload(self) -> None:
+        content = json.dumps(_FULL_TRANSLATION_RESPONSE)
+        client = self._mock_client(content)
+        _translate_text(_FULL_PAYLOAD, client, "mock-model", "en")
+
+        call_kwargs = client.chat.completions.create.call_args
+        messages = call_kwargs.kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert "en" in messages[0]["content"]
+        assert messages[1]["role"] == "user"
+        user_payload = json.loads(messages[1]["content"])
+        assert user_payload["event"]["title"] == "Tentoonstelling: Zichtbaarheid"
+
+    def test_uses_zero_temperature(self) -> None:
+        client = self._mock_client(json.dumps(_FULL_TRANSLATION_RESPONSE))
+        _translate_text(_FULL_PAYLOAD, client, "mock-model", "en")
+        call_kwargs = client.chat.completions.create.call_args
+        assert call_kwargs.kwargs["temperature"] == 0.0
+
+    def test_event_only_no_artifacts(self) -> None:
+        payload_no_artifacts = {
+            "event": {
+                "title": "Expo",
+                "description": "Desc",
+                "location_text": "Paris",
+            },
+            "artifacts": [],
+        }
+        response = {
+            "event": {"title": "Expo", "description": "Desc", "location_text": "Paris"},
+            "artifacts": [],
+        }
+        client = self._mock_client(json.dumps(response))
+        result = _translate_text(payload_no_artifacts, client, "mock-model", "en")
+        assert result["event"]["title"] == "Expo"
+        assert result["artifacts"] == []


### PR DESCRIPTION
## Summary

Implements the `artlake-translate` entry point (issue #22) that reads categorised/geocoded events from `artlake.bronze.categorised_events`, translates all text fields in a single LLM call per event, and writes to two new silver layer tables. Also standardises language codes to uppercase throughout the codebase (related to #38 data quality observation).

## Changes Made

- ✅ **New module**: `src/artlake/translate/content.py` — full translate pipeline with `list` and `translate` modes
- ✅ **New models**: `SilverEvent` and `SilverArtifact` Pydantic models in `src/artlake/models/event.py`
- ✅ **New DAB job**: `resources/translate_job.yml` — standalone translate-events job for isolated testing
- ✅ **Workflow integration**: `list_events_to_translate` + `translate_events` (for_each, concurrency 5) tasks added to `resources/ingest_events_job.yml`
- ✅ **Language code convention**: Standardised all language codes to uppercase (EN, NL, DE, FR) matching country code convention — applied to config files, Pydantic model defaults, code fallbacks, and prompt templates
- ✅ **Tests**: 31 unit tests in `tests/test_translate_content.py` covering all pure helpers and mocked LLM calls

## Key Features

- One LLM call per event translates all text fields (event title/description/location + artifact extracted_text/deadline/requirements/location/fees) in a single JSON payload
- Events already in target language are promoted to silver without an LLM call
- Anti-join with `artlake.silver.events` prevents re-translating already-processed rows
- `_parse_ts()` helper handles Delta's string-stored timestamps transparently
- Fallback to original text when LLM returns null for a field
- `backoff` retry with 3 attempts on LLM failures; errors promote event with original text rather than failing the run

## Silver Layer Tables

| Table | Description |
|-------|-------------|
| `artlake.silver.events` | Translated event fields + originals preserved |
| `artlake.silver.processed_artifacts` | Translated artifact content ready for vector store embedding |

## Testing

- ✅ 382 unit tests passing
- ✅ All pre-commit hooks pass (ruff, mypy)
- ✅ Pipeline deployed and run successfully on Databricks — Dutch → English translation verified
- ✅ `_parse_ts` fix validated: handles both `datetime` objects and ISO strings from Delta

## Related

- Closes #22 (Content translation)
- Partial data collected for #38 (artifact quality validation — needs wider pipeline run)
